### PR TITLE
Implement From/Into Vec<u8> for Address

### DIFF
--- a/crates/holochain_persistence_api/src/hash.rs
+++ b/crates/holochain_persistence_api/src/hash.rs
@@ -37,6 +37,21 @@ impl<'a> From<&'a str> for HashString {
     }
 }
 
+impl From<Vec<u8>> for HashString {
+    fn from(v: Vec<u8>) -> HashString {
+        let s : String = String::from_utf8_lossy(&v).into_owned();
+        HashString::from(s)
+    }
+}
+
+impl Into<Vec<u8>> for HashString {
+    fn into(self) -> Vec<u8> {
+        println!("u8 into!");
+        let s : String = self.into();
+        Vec::from(s.as_bytes())
+    }
+}
+
 impl HashString {
     pub fn new() -> HashString {
         HashString("".to_string())
@@ -120,4 +135,20 @@ pub mod tests {
                 .to_string(),
         );
     }
+
+ /*   #[test]
+    fn can_convert_hash_to_vec_u8() {
+        let hash_string = HashString::encode_from_str("test data", Hash::SHA2256);
+        let u : Vec<u8> = hash_string.into();
+        assert_eq!(u, [1, 2, 3, 4, 5]);
+    }
+*/
+    #[test]
+    fn can_convert_vec_u8_to_hash() {
+        let i : Vec<u8> = vec![48, 49, 50];
+        let hash_string : HashString = i.into();
+        assert_eq!("012", hash_string.to_string());
+        let u : Vec<u8> = hash_string.into();
+        assert_eq!(u, [48, 49, 50]);
+     }
 }

--- a/crates/holochain_persistence_api/src/hash.rs
+++ b/crates/holochain_persistence_api/src/hash.rs
@@ -46,7 +46,7 @@ impl From<Vec<u8>> for HashString {
 impl TryInto<Vec<u8>> for HashString {
     type Error = rust_base58::base58::FromBase58Error;
     fn try_into(self) -> Result<Vec<u8>, Self::Error> {
-        self.0.from_base58().map(|a| Vec::from(a))
+        self.0.from_base58()
     }
 }
 

--- a/crates/holochain_persistence_api/src/hash.rs
+++ b/crates/holochain_persistence_api/src/hash.rs
@@ -39,7 +39,7 @@ impl<'a> From<&'a str> for HashString {
 
 impl From<Vec<u8>> for HashString {
     fn from(v: Vec<u8>) -> HashString {
-        let s : String = String::from_utf8_lossy(&v).into_owned();
+        let s: String = String::from_utf8_lossy(&v).into_owned();
         HashString::from(s)
     }
 }
@@ -47,7 +47,7 @@ impl From<Vec<u8>> for HashString {
 impl Into<Vec<u8>> for HashString {
     fn into(self) -> Vec<u8> {
         println!("u8 into!");
-        let s : String = self.into();
+        let s: String = self.into();
         Vec::from(s.as_bytes())
     }
 }
@@ -136,19 +136,12 @@ pub mod tests {
         );
     }
 
- /*   #[test]
-    fn can_convert_hash_to_vec_u8() {
-        let hash_string = HashString::encode_from_str("test data", Hash::SHA2256);
-        let u : Vec<u8> = hash_string.into();
-        assert_eq!(u, [1, 2, 3, 4, 5]);
-    }
-*/
     #[test]
     fn can_convert_vec_u8_to_hash() {
-        let i : Vec<u8> = vec![48, 49, 50];
-        let hash_string : HashString = i.into();
+        let i: Vec<u8> = vec![48, 49, 50];
+        let hash_string: HashString = i.into();
         assert_eq!("012", hash_string.to_string());
-        let u : Vec<u8> = hash_string.into();
+        let u: Vec<u8> = hash_string.into();
         assert_eq!(u, [48, 49, 50]);
-     }
+    }
 }

--- a/crates/holochain_persistence_api/src/hash.rs
+++ b/crates/holochain_persistence_api/src/hash.rs
@@ -46,7 +46,6 @@ impl From<Vec<u8>> for HashString {
 
 impl Into<Vec<u8>> for HashString {
     fn into(self) -> Vec<u8> {
-        println!("u8 into!");
         let s: String = self.into();
         Vec::from(s.as_bytes())
     }


### PR DESCRIPTION
## PR summary

This PR extends the `cas::content::Address` type in `holochain_persistence_api` with `Into<Vec<u8>>` and  `From<Vec<u8>>` converters. This is to ease integration of the new lib3h client protocol into `holochain-core`, as their address types differ.

In a future PR we might want to consider just making all addresses a `Vec<u8>` but this would be a breaking change.



## Review checklist 
- [ ] The story has unit or integration tests
- [ ] No new bugs, and any tech-debt is identified and justified
- [ ] There is enough API documentation (how to use)
- [ ] There is enough code documentation (how the code works)
