### PR TITLE
Implement TryInto for &HashString

### DIFF
--- a/crates/holochain_persistence_api/Cargo.toml
+++ b/crates/holochain_persistence_api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_persistence_api"
-version = "0.0.3-alpha1"
+version = "0.0.4-alpha1"
 authors = ["Holochain Core Dev Team <devcore@holochain.org>"]
 build = "build.rs"
 description = "persistence api for content addressable storage and entity attribute value indexes"

--- a/crates/holochain_persistence_api/src/hash.rs
+++ b/crates/holochain_persistence_api/src/hash.rs
@@ -56,6 +56,13 @@ impl TryInto<Vec<u8>> for HashString {
     }
 }
 
+impl<'a> TryInto<Vec<u8>> for &'a HashString {
+    type Error = rust_base58::base58::FromBase58Error;
+    fn try_into(self) -> Result<Vec<u8>, Self::Error> {
+        self.clone().try_into()
+    }
+}
+
 impl HashString {
     pub fn new() -> HashString {
         HashString("".to_string())
@@ -147,8 +154,11 @@ pub mod tests {
         assert_eq!("HBrq", hash_string.to_string());
         let hash_string_from_ref: HashString = (&v).into();
         assert_eq!("HBrq", hash_string_from_ref.to_string());
-        let result: Result<Vec<u8>, _> = hash_string.try_into();
+        let result: Result<Vec<u8>, _> = hash_string.clone().try_into();
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), [48, 49, 50]);
+        let result_from_ref: Result<Vec<u8>, _> = (&hash_string).try_into();
+        assert!(result_from_ref.is_ok());
+        assert_eq!(result_from_ref.unwrap(), [48, 49, 50]);
     }
 }

--- a/crates/holochain_persistence_file/Cargo.toml
+++ b/crates/holochain_persistence_file/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_persistence_file"
-version = "0.0.3-alpha1"
+version = "0.0.4-alpha1"
 authors = ["Holochain Core Dev Team <devcore@holochain.org>"]
 edition = "2018"
 description = "persistence for content addressable storage and entity attribute value indexes. A file system based implementation using directory hieraarchies to navigate data."
@@ -17,7 +17,7 @@ serde = "=1.0.89"
 serde_derive = "=1.0.89"
 serde_test = "=1.0.89"
 multihash = "=0.8.0"
-holochain_persistence_api = { path = "../holochain_persistence_api", version= "=0.0.3-alpha1" }
+holochain_persistence_api = { path = "../holochain_persistence_api", version= "=0.0.4-alpha1" }
 holochain_json_api = "=0.0.1-alpha2"
 lazy_static = "=1.2.0"
 glob = "=0.3.0"

--- a/crates/holochain_persistence_mem/Cargo.toml
+++ b/crates/holochain_persistence_mem/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_persistence_mem"
-version = "0.0.3-alpha1"
+version = "0.0.4-alpha1"
 authors = ["Holochain Core Dev Team <devcore@holochain.org>"]
 edition = "2018"
 description = "persistence for content addressable storage and entity attribute value indexes. A simple, thread-safe in memory store."
@@ -17,7 +17,7 @@ serde = "=1.0.89"
 serde_derive = "=1.0.89"
 serde_test = "=1.0.89"
 multihash = "=0.8.0"
-holochain_persistence_api = { path = "../holochain_persistence_api", version= "=0.0.3-alpha1" }
+holochain_persistence_api = { path = "../holochain_persistence_api", version= "=0.0.4-alpha1" }
 holochain_json_api = "=0.0.1-alpha2"
 lazy_static = "=1.2.0"
 glob = "=0.3.0"

--- a/crates/holochain_persistence_pickle/Cargo.toml
+++ b/crates/holochain_persistence_pickle/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_persistence_pickle"
-version = "0.0.3-alpha1"
+version = "0.0.4-alpha1"
 authors = ["Holochain Core Dev Team <devcore@holochain.org>"]
 edition = "2018"
 description = "persistence for content addressable storage and entity attribute value indexes backed by pickledb-rs."
@@ -17,7 +17,7 @@ serde = "=1.0.89"
 serde_derive = "=1.0.89"
 serde_test = "=1.0.89"
 multihash = "=0.8.0"
-holochain_persistence_api = { path = "../holochain_persistence_api", version= "=0.0.3-alpha1" }
+holochain_persistence_api = { path = "../holochain_persistence_api", version= "=0.0.4-alpha1" }
 
 holochain_json_api = "=0.0.1-alpha2"
 lazy_static = "=1.2.0"


### PR DESCRIPTION
## PR summary

This implements `TryFrom<Vec<u8>> for &'a HashString` (avoids an extra clone by users of these converters).

## Review checklist 
- [ ] The story has unit or integration tests
- [ ] No new bugs, and any tech-debt is identified and justified
- [ ] There is enough API documentation (how to use)
- [ ] There is enough code documentation (how the code works)
