### PR TITLE
Feature/add storage reporting

### DIFF
--- a/crates/holochain_persistence_api/src/cas/storage.rs
+++ b/crates/holochain_persistence_api/src/cas/storage.rs
@@ -9,6 +9,7 @@ use crate::{
         Attribute, EavFilter, EaviQuery, EntityAttributeValueIndex, EntityAttributeValueStorage,
         IndexFilter,
     },
+    reporting::ReportStorage,
     error::{PersistenceError, PersistenceResult},
     holochain_json_api::{
         error::JsonError,
@@ -29,7 +30,7 @@ use uuid::Uuid;
 /// implements storage in memory or persistently
 /// anything implementing AddressableContent can be added and fetched by address
 /// CAS is append only
-pub trait ContentAddressableStorage: objekt::Clone + Send + Sync + Debug {
+pub trait ContentAddressableStorage: objekt::Clone + Send + Sync + Debug + ReportStorage {
     /// adds AddressableContent to the ContentAddressableStorage by its Address as Content
     fn add(&mut self, content: &dyn AddressableContent) -> PersistenceResult<()>;
     /// true if the Address is in the Store, false otherwise.
@@ -100,6 +101,8 @@ impl ContentAddressableStorage for ExampleContentAddressableStorage {
         Uuid::new_v4()
     }
 }
+
+impl ReportStorage for ExampleContentAddressableStorage {}
 
 #[derive(Debug, Default)]
 /// Not thread-safe CAS implementation with a HashMap

--- a/crates/holochain_persistence_api/src/cas/storage.rs
+++ b/crates/holochain_persistence_api/src/cas/storage.rs
@@ -9,13 +9,13 @@ use crate::{
         Attribute, EavFilter, EaviQuery, EntityAttributeValueIndex, EntityAttributeValueStorage,
         IndexFilter,
     },
-    reporting::ReportStorage,
     error::{PersistenceError, PersistenceResult},
     holochain_json_api::{
         error::JsonError,
         json::{JsonString, RawString},
     },
     regex::Regex,
+    reporting::ReportStorage,
 };
 use objekt;
 use std::{

--- a/crates/holochain_persistence_api/src/eav/storage.rs
+++ b/crates/holochain_persistence_api/src/eav/storage.rs
@@ -1,4 +1,5 @@
 use eav::{eavi::EntityAttributeValueIndex, query::EaviQuery, Attribute};
+use reporting::ReportStorage;
 use error::PersistenceResult;
 use objekt;
 use std::{
@@ -10,7 +11,7 @@ use std::{
 /// This provides a simple and flexible interface to define relationships between AddressableContent.
 /// It does NOT provide storage for AddressableContent.
 /// Use cas::storage::ContentAddressableStorage to store AddressableContent.
-pub trait EntityAttributeValueStorage<A: Attribute>: objekt::Clone + Send + Sync + Debug {
+pub trait EntityAttributeValueStorage<A: Attribute>: objekt::Clone + Send + Sync + Debug + ReportStorage {
     /// Adds the given EntityAttributeValue to the EntityAttributeValueStorage
     /// append only storage.
     fn add_eavi(
@@ -74,6 +75,8 @@ where
         Ok(query.run(iter))
     }
 }
+
+impl<A: Attribute> ReportStorage for ExampleEntityAttributeValueStorage<A> {}
 
 impl<A: Attribute> PartialEq for dyn EntityAttributeValueStorage<A> {
     fn eq(&self, other: &dyn EntityAttributeValueStorage<A>) -> bool {

--- a/crates/holochain_persistence_api/src/eav/storage.rs
+++ b/crates/holochain_persistence_api/src/eav/storage.rs
@@ -1,7 +1,7 @@
 use eav::{eavi::EntityAttributeValueIndex, query::EaviQuery, Attribute};
-use reporting::ReportStorage;
 use error::PersistenceResult;
 use objekt;
+use reporting::ReportStorage;
 use std::{
     collections::BTreeSet,
     fmt::Debug,
@@ -11,7 +11,9 @@ use std::{
 /// This provides a simple and flexible interface to define relationships between AddressableContent.
 /// It does NOT provide storage for AddressableContent.
 /// Use cas::storage::ContentAddressableStorage to store AddressableContent.
-pub trait EntityAttributeValueStorage<A: Attribute>: objekt::Clone + Send + Sync + Debug + ReportStorage {
+pub trait EntityAttributeValueStorage<A: Attribute>:
+    objekt::Clone + Send + Sync + Debug + ReportStorage
+{
     /// Adds the given EntityAttributeValue to the EntityAttributeValueStorage
     /// append only storage.
     fn add_eavi(

--- a/crates/holochain_persistence_api/src/lib.rs
+++ b/crates/holochain_persistence_api/src/lib.rs
@@ -24,6 +24,7 @@ pub mod cas;
 pub mod eav;
 pub mod error;
 pub mod hash;
+pub mod reporting;
 
 #[macro_use]
 extern crate objekt;

--- a/crates/holochain_persistence_api/src/reporting.rs
+++ b/crates/holochain_persistence_api/src/reporting.rs
@@ -1,10 +1,12 @@
-use super::error::{PersistenceResult, PersistenceError};
+use super::error::{PersistenceError, PersistenceResult};
 
 pub trait ReportStorage {
-	/// Return the number of bytes this storage implementation is using on the host system.
-	/// The actual implementation is up to the author of the persistence implementation
-	/// and may be disk usage or memory usage
-	fn get_byte_count(&self) -> PersistenceResult<usize> {
-		Err(PersistenceError::ErrorGeneric("Not implemented for this storage type".into()))
-	}
+    /// Return the number of bytes this storage implementation is using on the host system.
+    /// The actual implementation is up to the author of the persistence implementation
+    /// and may be disk usage or memory usage
+    fn get_byte_count(&self) -> PersistenceResult<usize> {
+        Err(PersistenceError::ErrorGeneric(
+            "Not implemented for this storage type".into(),
+        ))
+    }
 }

--- a/crates/holochain_persistence_api/src/reporting.rs
+++ b/crates/holochain_persistence_api/src/reporting.rs
@@ -1,0 +1,10 @@
+use super::error::{PersistenceResult, PersistenceError};
+
+pub trait ReportStorage {
+	/// Return the number of bytes this storage implementation is using on the host system.
+	/// The actual implementation is up to the author of the persistence implementation
+	/// and may be disk usage or memory usage
+	fn get_byte_count(&self) -> PersistenceResult<usize> {
+		Err(PersistenceError::ErrorGeneric("Not implemented for this storage type".into()))
+	}
+}

--- a/crates/holochain_persistence_api/src/reporting.rs
+++ b/crates/holochain_persistence_api/src/reporting.rs
@@ -2,15 +2,13 @@ use super::error::{PersistenceError, PersistenceResult};
 
 #[derive(Debug, PartialEq)]
 pub struct StorageReport {
-	pub bytes_total: usize,
+    pub bytes_total: usize,
 }
 
 impl StorageReport {
-	pub fn new(bytes_total: usize) -> Self {
-		Self {
-			bytes_total
-		}
-	}
+    pub fn new(bytes_total: usize) -> Self {
+        Self { bytes_total }
+    }
 }
 
 pub trait ReportStorage {

--- a/crates/holochain_persistence_api/src/reporting.rs
+++ b/crates/holochain_persistence_api/src/reporting.rs
@@ -1,10 +1,23 @@
 use super::error::{PersistenceError, PersistenceResult};
 
+#[derive(Debug, PartialEq)]
+pub struct StorageReport {
+	pub bytes_total: usize,
+}
+
+impl StorageReport {
+	pub fn new(bytes_total: usize) -> Self {
+		Self {
+			bytes_total
+		}
+	}
+}
+
 pub trait ReportStorage {
     /// Return the number of bytes this storage implementation is using on the host system.
     /// The actual implementation is up to the author of the persistence implementation
     /// and may be disk usage or memory usage
-    fn get_byte_count(&self) -> PersistenceResult<usize> {
+    fn get_storage_report(&self) -> PersistenceResult<StorageReport> {
         Err(PersistenceError::ErrorGeneric(
             "Not implemented for this storage type".into(),
         ))

--- a/crates/holochain_persistence_file/src/cas/file.rs
+++ b/crates/holochain_persistence_file/src/cas/file.rs
@@ -5,6 +5,7 @@ use holochain_persistence_api::{
         storage::ContentAddressableStorage,
     },
     error::PersistenceResult,
+    reporting::ReportStorage,
 };
 
 use std::{
@@ -85,6 +86,8 @@ impl ContentAddressableStorage for FilesystemStorage {
         self.id
     }
 }
+
+impl ReportStorage for FilesystemStorage {}
 
 #[cfg(test)]
 pub mod tests {

--- a/crates/holochain_persistence_file/src/eav/file.rs
+++ b/crates/holochain_persistence_file/src/eav/file.rs
@@ -10,6 +10,7 @@ use holochain_persistence_api::{
         EntityAttributeValueStorage, Value,
     },
     error::{PersistenceError, PersistenceResult},
+    reporting::ReportStorage,
 };
 use std::{
     collections::BTreeSet,
@@ -242,6 +243,8 @@ where
         }
     }
 }
+
+impl<A: Attribute> ReportStorage for EavFileStorage<A> {}
 
 #[cfg(test)]
 pub mod tests {

--- a/crates/holochain_persistence_mem/src/cas/memory.rs
+++ b/crates/holochain_persistence_mem/src/cas/memory.rs
@@ -4,6 +4,7 @@ use holochain_persistence_api::{
         storage::ContentAddressableStorage,
     },
     error::PersistenceResult,
+    reporting::ReportStorage,
 };
 
 use std::{
@@ -59,6 +60,8 @@ impl ContentAddressableStorage for MemoryStorage {
         self.id
     }
 }
+
+impl ReportStorage for MemoryStorage {}
 
 #[cfg(test)]
 pub mod tests {

--- a/crates/holochain_persistence_mem/src/eav/memory.rs
+++ b/crates/holochain_persistence_mem/src/eav/memory.rs
@@ -4,6 +4,7 @@ use holochain_persistence_api::{
         EntityAttributeValueStorage,
     },
     error::PersistenceResult,
+    reporting::ReportStorage,
 };
 use std::{
     collections::BTreeSet,
@@ -62,6 +63,8 @@ where
         Ok(query.run(iter))
     }
 }
+
+impl<A: Attribute> ReportStorage for EavMemoryStorage<A> {}
 
 #[cfg(test)]
 pub mod tests {

--- a/crates/holochain_persistence_pickle/src/cas/pickle.rs
+++ b/crates/holochain_persistence_pickle/src/cas/pickle.rs
@@ -131,10 +131,7 @@ mod tests {
         // add some content
         cas.add(&Content::from_json("some bytes"))
             .expect("could not add to CAS");
-        assert_eq!(
-            cas.get_storage_report().unwrap(), 
-            StorageReport::new(10),
-        );
+        assert_eq!(cas.get_storage_report().unwrap(), StorageReport::new(10),);
 
         // add some more
         cas.add(&Content::from_json("more bytes"))

--- a/crates/holochain_persistence_pickle/src/cas/pickle.rs
+++ b/crates/holochain_persistence_pickle/src/cas/pickle.rs
@@ -87,8 +87,7 @@ impl ContentAddressableStorage for PickleStorage {
 impl ReportStorage for PickleStorage {
     fn get_byte_count(&self) -> PersistenceResult<usize> {
         let db = self.db.read()?;
-        Ok(db.iter()
-        .fold(0, |total_bytes, kv| {
+        Ok(db.iter().fold(0, |total_bytes, kv| {
             let value = kv.get_value::<Content>().unwrap();
             total_bytes + value.to_string().bytes().len()
         }))
@@ -99,11 +98,13 @@ impl ReportStorage for PickleStorage {
 mod tests {
     use crate::cas::pickle::PickleStorage;
     use holochain_json_api::json::RawString;
-    use holochain_persistence_api::cas::{
-        content::{Content, ExampleAddressableContent, OtherExampleAddressableContent},
-        storage::{StorageTestSuite, ContentAddressableStorage},
+    use holochain_persistence_api::{
+        cas::{
+            content::{Content, ExampleAddressableContent, OtherExampleAddressableContent},
+            storage::{ContentAddressableStorage, StorageTestSuite},
+        },
+        reporting::ReportStorage,
     };
-    use holochain_persistence_api::reporting::ReportStorage;
     use tempfile::{tempdir, TempDir};
 
     pub fn test_pickle_cas() -> (PickleStorage, TempDir) {
@@ -125,19 +126,15 @@ mod tests {
 
     #[test]
     fn pickle_report_storage_test() {
-        let (mut cas, _)  = test_pickle_cas();
+        let (mut cas, _) = test_pickle_cas();
         // add some content
-        cas.add(&Content::from_json("some bytes")).expect("could not add to CAS");
-        assert_eq!(
-            cas.get_byte_count().unwrap(),
-            10,
-        );
+        cas.add(&Content::from_json("some bytes"))
+            .expect("could not add to CAS");
+        assert_eq!(cas.get_byte_count().unwrap(), 10,);
 
         // add some more
-        cas.add(&Content::from_json("more bytes")).expect("could not add to CAS");
-        assert_eq!(
-            cas.get_byte_count().unwrap(),
-            10+10,
-        );
+        cas.add(&Content::from_json("more bytes"))
+            .expect("could not add to CAS");
+        assert_eq!(cas.get_byte_count().unwrap(), 10 + 10,);
     }
 }

--- a/crates/holochain_persistence_pickle/src/eav/pickle.rs
+++ b/crates/holochain_persistence_pickle/src/eav/pickle.rs
@@ -1,9 +1,9 @@
 use holochain_json_api::error::JsonError;
 use holochain_persistence_api::{
+    cas::content::AddressableContent,
     eav::{Attribute, EaviQuery, EntityAttributeValueIndex, EntityAttributeValueStorage},
     error::PersistenceResult,
     reporting::ReportStorage,
-    cas::content::AddressableContent,
 };
 
 use pickledb::{PickleDb, PickleDbDumpPolicy, SerializationMethod};
@@ -108,8 +108,7 @@ where
 {
     fn get_byte_count(&self) -> PersistenceResult<usize> {
         let db = self.db.read()?;
-        Ok(db.iter()
-        .fold(0, |total_bytes, kv| {
+        Ok(db.iter().fold(0, |total_bytes, kv| {
             let value = kv.get_value::<EntityAttributeValueIndex<A>>().unwrap();
             total_bytes + value.content().to_string().bytes().len()
         }))

--- a/crates/holochain_persistence_pickle/src/eav/pickle.rs
+++ b/crates/holochain_persistence_pickle/src/eav/pickle.rs
@@ -3,7 +3,7 @@ use holochain_persistence_api::{
     cas::content::AddressableContent,
     eav::{Attribute, EaviQuery, EntityAttributeValueIndex, EntityAttributeValueStorage},
     error::PersistenceResult,
-    reporting::ReportStorage,
+    reporting::{ReportStorage, StorageReport},
 };
 
 use pickledb::{PickleDb, PickleDbDumpPolicy, SerializationMethod};
@@ -106,12 +106,13 @@ impl<A: Attribute> ReportStorage for EavPickleStorage<A>
 where
     A: Sync + Send + serde::de::DeserializeOwned,
 {
-    fn get_byte_count(&self) -> PersistenceResult<usize> {
+    fn get_storage_report(&self) -> PersistenceResult<StorageReport> {
         let db = self.db.read()?;
-        Ok(db.iter().fold(0, |total_bytes, kv| {
+        let total_bytes = db.iter().fold(0, |total_bytes, kv| {
             let value = kv.get_value::<EntityAttributeValueIndex<A>>().unwrap();
             total_bytes + value.content().to_string().bytes().len()
-        }))
+        });
+        Ok(StorageReport::new(total_bytes))
     }
 }
 


### PR DESCRIPTION
## PR summary

This is pre-work to enable the conductor to report disk usage for Holo purposes.

Adds a trait `ReportStorage` that the storage implementations can implement to return the number of bytes they are currently occupying on the host device. 

Adds a naive implementation for pickle CAS and EAV

## Review checklist 
- [ ] The story has unit or integration tests
- [ ] No new bugs, and any tech-debt is identified and justified
- [ ] There is enough API documentation (how to use)
- [ ] There is enough code documentation (how the code works)
