### PR TITLE
Add lmdb store

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,4 +5,5 @@ members = [
   "crates/holochain_persistence_mem",
   "crates/holochain_persistence_file",
   "crates/holochain_persistence_pickle",
+  "crates/holochain_persistence_lmdb",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,5 +6,5 @@ members = [
   "crates/holochain_persistence_file",
   "crates/holochain_persistence_pickle",
   "crates/holochain_persistence_lmdb",
-  "benchmarks",
+  # "benchmarks",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,4 +6,5 @@ members = [
   "crates/holochain_persistence_file",
   "crates/holochain_persistence_pickle",
   "crates/holochain_persistence_lmdb",
+  "benchmarks",
 ]

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "benchmarks"
+version = "0.0.8"
+authors = ["Holochain Core Dev Team <devcore@holochain.org>"]
+
+[dependencies]
+holochain_persistence_api = { path = "../crates/holochain_persistence_api" }
+holochain_persistence_file = { path = "../crates/holochain_persistence_file" }
+holochain_persistence_mem = { path = "../crates/holochain_persistence_mem" }
+holochain_persistence_pickle = { path = "../crates/holochain_persistence_pickle" }
+holochain_persistence_lmdb = { path = "../crates/holochain_persistence_lmdb" }
+bencher = "=0.1.5"
+tempfile = "=3.0.7"
+
+
+
+[[bench]]
+name = "my_benchmark"
+harness = false

--- a/benchmarks/benches/my_benchmark.rs
+++ b/benchmarks/benches/my_benchmark.rs
@@ -10,7 +10,7 @@ extern crate tempfile;
 use self::tempfile::tempdir;
 use bencher::Bencher;
 use holochain_persistence_api::{
-    cas::{content::Content, content::ExampleAddressableContent, storage::EavTestSuite},
+    cas::{content::ExampleAddressableContent, storage::EavTestSuite},
     eav::eavi::ExampleAttribute,
 };
 use holochain_persistence_file::eav::file::EavFileStorage;
@@ -22,8 +22,8 @@ use holochain_persistence_lmdb::eav::lmdb::EavLmdbStorage;
 
 
 fn bench_memory_eav_one_to_many(b: &mut Bencher) {
-    let eav_storage = EavMemoryStorage::new();
     b.iter(|| {
+        let eav_storage = EavMemoryStorage::new();
         EavTestSuite::test_one_to_many::<
             ExampleAddressableContent,
             ExampleAttribute,
@@ -33,8 +33,8 @@ fn bench_memory_eav_one_to_many(b: &mut Bencher) {
 }
 
 fn bench_memory_eav_many_to_one(b: &mut Bencher) {
-    let eav_storage = EavMemoryStorage::new();
     b.iter(|| {
+        let eav_storage = EavMemoryStorage::new();
         EavTestSuite::test_one_to_many::<
             ExampleAddressableContent,
             ExampleAttribute,
@@ -47,10 +47,10 @@ fn bench_memory_eav_many_to_one(b: &mut Bencher) {
 
 
 fn bench_file_eav_one_to_many(b: &mut Bencher) {
-    let temp = tempdir().expect("test was supposed to create temp dir");
-    let temp_path = String::from(temp.path().to_str().expect("temp dir could not be string"));
-    let eav_storage = EavFileStorage::new(temp_path).unwrap();
     b.iter(|| {
+        let temp = tempdir().expect("test was supposed to create temp dir");
+        let temp_path = String::from(temp.path().to_str().expect("temp dir could not be string"));
+        let eav_storage = EavFileStorage::new(temp_path).unwrap();
         EavTestSuite::test_one_to_many::<
             ExampleAddressableContent,
             ExampleAttribute,
@@ -60,10 +60,10 @@ fn bench_file_eav_one_to_many(b: &mut Bencher) {
 }
 
 fn bench_file_eav_many_to_one(b: &mut Bencher) {
-    let temp = tempdir().expect("test was supposed to create temp dir");
-    let temp_path = String::from(temp.path().to_str().expect("temp dir could not be string"));
-    let eav_storage = EavFileStorage::new(temp_path).unwrap();
     b.iter(|| {
+        let temp = tempdir().expect("test was supposed to create temp dir");
+        let temp_path = String::from(temp.path().to_str().expect("temp dir could not be string"));
+        let eav_storage = EavFileStorage::new(temp_path).unwrap();
         EavTestSuite::test_many_to_one::<
             ExampleAddressableContent,
             ExampleAttribute,
@@ -76,10 +76,10 @@ fn bench_file_eav_many_to_one(b: &mut Bencher) {
 
 
 fn bench_pickle_eav_one_to_many(b: &mut Bencher) {
-    let temp = tempdir().expect("test was supposed to create temp dir");
-    let temp_path = String::from(temp.path().to_str().expect("temp dir could not be string"));
-    let eav_storage = EavPickleStorage::new(temp_path);
     b.iter(|| {
+        let temp = tempdir().expect("test was supposed to create temp dir");
+        let temp_path = String::from(temp.path().to_str().expect("temp dir could not be string"));
+        let eav_storage = EavPickleStorage::new(temp_path);
         EavTestSuite::test_one_to_many::<
             ExampleAddressableContent,
             ExampleAttribute,
@@ -89,10 +89,10 @@ fn bench_pickle_eav_one_to_many(b: &mut Bencher) {
 }
 
 fn bench_pickle_eav_many_to_one(b: &mut Bencher) {
-    let temp = tempdir().expect("test was supposed to create temp dir");
-    let temp_path = String::from(temp.path().to_str().expect("temp dir could not be string"));
-    let eav_storage = EavPickleStorage::new(temp_path);
     b.iter(|| {
+        let temp = tempdir().expect("test was supposed to create temp dir");
+        let temp_path = String::from(temp.path().to_str().expect("temp dir could not be string"));
+        let eav_storage = EavPickleStorage::new(temp_path);
         EavTestSuite::test_many_to_one::<
             ExampleAddressableContent,
             ExampleAttribute,
@@ -104,10 +104,10 @@ fn bench_pickle_eav_many_to_one(b: &mut Bencher) {
 /*----------  LMDB Storage  ----------*/
 
 fn bench_lmdb_eav_one_to_many(b: &mut Bencher) {
-    let temp = tempdir().expect("test was supposed to create temp dir");
-    let temp_path = String::from(temp.path().to_str().expect("temp dir could not be string"));
-    let eav_storage = EavLmdbStorage::new(temp_path);
     b.iter(|| {
+        let temp = tempdir().expect("test was supposed to create temp dir");
+        let temp_path = String::from(temp.path().to_str().expect("temp dir could not be string"));
+        let eav_storage = EavLmdbStorage::new(temp_path);
         EavTestSuite::test_one_to_many::<
             ExampleAddressableContent,
             ExampleAttribute,
@@ -117,30 +117,15 @@ fn bench_lmdb_eav_one_to_many(b: &mut Bencher) {
 }
 
 fn bench_lmdb_eav_many_to_one(b: &mut Bencher) {
-    let temp = tempdir().expect("test was supposed to create temp dir");
-    let temp_path = String::from(temp.path().to_str().expect("temp dir could not be string"));
-    let eav_storage = EavLmdbStorage::new(temp_path);
     b.iter(|| {
+        let temp = tempdir().expect("test was supposed to create temp dir");
+        let temp_path = String::from(temp.path().to_str().expect("temp dir could not be string"));
+        let eav_storage = EavLmdbStorage::new(temp_path);
         EavTestSuite::test_many_to_one::<
             ExampleAddressableContent,
             ExampleAttribute,
             EavLmdbStorage<ExampleAttribute>,
         >(eav_storage.clone(), &ExampleAttribute::WithoutPayload)
-    })
-}
-
-fn bench_lmdb_eav_round_trip(b: &mut Bencher) {
-    let temp = tempdir().expect("test was supposed to create temp dir");
-    let temp_path = String::from(temp.path().to_str().expect("temp dir could not be string"));
-    let eav_storage = EavLmdbStorage::new(temp_path);
-
-    b.iter(|| {
-        EavTestSuite::test_round_trip(
-            eav_storage.clone(),
-            Content::from_json("feep"),
-            ExampleAttribute::WithoutPayload,
-            Content::from_json("foo"),
-        )
     })
 }
 
@@ -154,6 +139,5 @@ benchmark_group!(
     bench_pickle_eav_one_to_many,
     bench_lmdb_eav_many_to_one,
     bench_lmdb_eav_one_to_many,
-    bench_lmdb_eav_round_trip,
 );
 benchmark_main!(benches);

--- a/benchmarks/benches/my_benchmark.rs
+++ b/benchmarks/benches/my_benchmark.rs
@@ -1,0 +1,159 @@
+#[macro_use]
+extern crate bencher;
+extern crate holochain_persistence_api;
+extern crate holochain_persistence_file;
+extern crate holochain_persistence_mem;
+extern crate holochain_persistence_pickle;
+extern crate holochain_persistence_lmdb;
+extern crate tempfile;
+
+use self::tempfile::tempdir;
+use bencher::Bencher;
+use holochain_persistence_api::{
+    cas::{content::Content, content::ExampleAddressableContent, storage::EavTestSuite},
+    eav::eavi::ExampleAttribute,
+};
+use holochain_persistence_file::eav::file::EavFileStorage;
+use holochain_persistence_mem::eav::memory::EavMemoryStorage;
+use holochain_persistence_pickle::eav::pickle::EavPickleStorage;
+use holochain_persistence_lmdb::eav::lmdb::EavLmdbStorage;
+
+/*----------  Memory Storage  ----------*/
+
+
+fn bench_memory_eav_one_to_many(b: &mut Bencher) {
+    let eav_storage = EavMemoryStorage::new();
+    b.iter(|| {
+        EavTestSuite::test_one_to_many::<
+            ExampleAddressableContent,
+            ExampleAttribute,
+            EavMemoryStorage<ExampleAttribute>,
+        >(eav_storage.clone(), &ExampleAttribute::WithoutPayload)
+    })
+}
+
+fn bench_memory_eav_many_to_one(b: &mut Bencher) {
+    let eav_storage = EavMemoryStorage::new();
+    b.iter(|| {
+        EavTestSuite::test_one_to_many::<
+            ExampleAddressableContent,
+            ExampleAttribute,
+            EavMemoryStorage<ExampleAttribute>,
+        >(eav_storage.clone(), &ExampleAttribute::WithoutPayload)
+    })
+}
+
+/*----------  File Storage  ----------*/
+
+
+fn bench_file_eav_one_to_many(b: &mut Bencher) {
+    let temp = tempdir().expect("test was supposed to create temp dir");
+    let temp_path = String::from(temp.path().to_str().expect("temp dir could not be string"));
+    let eav_storage = EavFileStorage::new(temp_path).unwrap();
+    b.iter(|| {
+        EavTestSuite::test_one_to_many::<
+            ExampleAddressableContent,
+            ExampleAttribute,
+            EavFileStorage<ExampleAttribute>,
+        >(eav_storage.clone(), &&ExampleAttribute::WithoutPayload)
+    })
+}
+
+fn bench_file_eav_many_to_one(b: &mut Bencher) {
+    let temp = tempdir().expect("test was supposed to create temp dir");
+    let temp_path = String::from(temp.path().to_str().expect("temp dir could not be string"));
+    let eav_storage = EavFileStorage::new(temp_path).unwrap();
+    b.iter(|| {
+        EavTestSuite::test_many_to_one::<
+            ExampleAddressableContent,
+            ExampleAttribute,
+            EavFileStorage<ExampleAttribute>,
+        >(eav_storage.clone(), &ExampleAttribute::WithoutPayload)
+    })
+}
+
+/*----------  Pickle Storage  ----------*/
+
+
+fn bench_pickle_eav_one_to_many(b: &mut Bencher) {
+    let temp = tempdir().expect("test was supposed to create temp dir");
+    let temp_path = String::from(temp.path().to_str().expect("temp dir could not be string"));
+    let eav_storage = EavPickleStorage::new(temp_path);
+    b.iter(|| {
+        EavTestSuite::test_one_to_many::<
+            ExampleAddressableContent,
+            ExampleAttribute,
+            EavPickleStorage<ExampleAttribute>,
+        >(eav_storage.clone(), &ExampleAttribute::WithoutPayload)
+    })
+}
+
+fn bench_pickle_eav_many_to_one(b: &mut Bencher) {
+    let temp = tempdir().expect("test was supposed to create temp dir");
+    let temp_path = String::from(temp.path().to_str().expect("temp dir could not be string"));
+    let eav_storage = EavPickleStorage::new(temp_path);
+    b.iter(|| {
+        EavTestSuite::test_many_to_one::<
+            ExampleAddressableContent,
+            ExampleAttribute,
+            EavPickleStorage<ExampleAttribute>,
+        >(eav_storage.clone(), &ExampleAttribute::WithoutPayload)
+    })
+}
+
+/*----------  LMDB Storage  ----------*/
+
+fn bench_lmdb_eav_one_to_many(b: &mut Bencher) {
+    let temp = tempdir().expect("test was supposed to create temp dir");
+    let temp_path = String::from(temp.path().to_str().expect("temp dir could not be string"));
+    let eav_storage = EavLmdbStorage::new(temp_path);
+    b.iter(|| {
+        EavTestSuite::test_one_to_many::<
+            ExampleAddressableContent,
+            ExampleAttribute,
+            EavLmdbStorage<ExampleAttribute>,
+        >(eav_storage.clone(), &ExampleAttribute::WithoutPayload)
+    })
+}
+
+fn bench_lmdb_eav_many_to_one(b: &mut Bencher) {
+    let temp = tempdir().expect("test was supposed to create temp dir");
+    let temp_path = String::from(temp.path().to_str().expect("temp dir could not be string"));
+    let eav_storage = EavLmdbStorage::new(temp_path);
+    b.iter(|| {
+        EavTestSuite::test_many_to_one::<
+            ExampleAddressableContent,
+            ExampleAttribute,
+            EavLmdbStorage<ExampleAttribute>,
+        >(eav_storage.clone(), &ExampleAttribute::WithoutPayload)
+    })
+}
+
+fn bench_lmdb_eav_round_trip(b: &mut Bencher) {
+    let temp = tempdir().expect("test was supposed to create temp dir");
+    let temp_path = String::from(temp.path().to_str().expect("temp dir could not be string"));
+    let eav_storage = EavLmdbStorage::new(temp_path);
+
+    b.iter(|| {
+        EavTestSuite::test_round_trip(
+            eav_storage.clone(),
+            Content::from_json("feep"),
+            ExampleAttribute::WithoutPayload,
+            Content::from_json("foo"),
+        )
+    })
+}
+
+benchmark_group!(
+    benches,
+    bench_memory_eav_many_to_one,
+    bench_memory_eav_one_to_many,
+    bench_file_eav_one_to_many,
+    bench_file_eav_many_to_one,
+    bench_pickle_eav_many_to_one,
+    bench_pickle_eav_one_to_many,
+    bench_lmdb_eav_many_to_one,
+    bench_lmdb_eav_one_to_many,
+    bench_lmdb_eav_round_trip,
+);
+benchmark_main!(benches);

--- a/crates/holochain_persistence_api/Cargo.toml
+++ b/crates/holochain_persistence_api/Cargo.toml
@@ -35,6 +35,7 @@ objekt= "=0.1.2"
 holochain_json_api = "=0.0.17"
 holochain_json_derive = "=0.0.17"
 uuid = { version = "=0.7.1", features = ["v4"] }
+rand = "0.7.2"
 
 [dev-dependencies]
 maplit = "=1.0.1"

--- a/crates/holochain_persistence_api/src/cas/storage.rs
+++ b/crates/holochain_persistence_api/src/cas/storage.rs
@@ -834,12 +834,15 @@ impl CasBencher {
         mut store: impl ContentAddressableStorage,       
     ) {
         // add some values to make it realistic
-        for _ in 0..10 {
+        for _ in 0..100 {
             store.add(&CasBencher::random_addressable_content()).unwrap();
         }
 
+        let test_content = CasBencher::random_addressable_content();
+        store.add(&test_content).unwrap();
+
         b.iter(|| {
-            store.fetch(&Address::from("Qm..."))     
+            store.fetch(&test_content.address())     
         })        
     }
 }

--- a/crates/holochain_persistence_api/src/cas/storage.rs
+++ b/crates/holochain_persistence_api/src/cas/storage.rs
@@ -814,36 +814,27 @@ impl EavTestSuite {
 pub struct CasBencher;
 
 impl CasBencher {
-
     fn random_addressable_content() -> ExampleAddressableContent {
         let s: String = (0..4).map(|_| rand::random::<char>()).collect();
         ExampleAddressableContent::try_from_content(&RawString::from(s).into()).unwrap()
     }
 
-    pub fn bench_add(
-        b: &mut test::Bencher,
-        mut store: impl ContentAddressableStorage,
-    ) {
-        b.iter(|| {
-            store.add(&CasBencher::random_addressable_content())     
-        })
+    pub fn bench_add(b: &mut test::Bencher, mut store: impl ContentAddressableStorage) {
+        b.iter(|| store.add(&CasBencher::random_addressable_content()))
     }
 
-    pub fn bench_fetch(
-        b: &mut test::Bencher,
-        mut store: impl ContentAddressableStorage,       
-    ) {
+    pub fn bench_fetch(b: &mut test::Bencher, mut store: impl ContentAddressableStorage) {
         // add some values to make it realistic
         for _ in 0..100 {
-            store.add(&CasBencher::random_addressable_content()).unwrap();
+            store
+                .add(&CasBencher::random_addressable_content())
+                .unwrap();
         }
 
         let test_content = CasBencher::random_addressable_content();
         store.add(&test_content).unwrap();
 
-        b.iter(|| {
-            store.fetch(&test_content.address())     
-        })        
+        b.iter(|| store.fetch(&test_content.address()))
     }
 }
 

--- a/crates/holochain_persistence_api/src/cas/storage.rs
+++ b/crates/holochain_persistence_api/src/cas/storage.rs
@@ -814,7 +814,7 @@ impl EavTestSuite {
 pub struct CasBencher;
 
 impl CasBencher {
-    fn random_addressable_content() -> ExampleAddressableContent {
+    pub fn random_addressable_content() -> ExampleAddressableContent {
         let s: String = (0..4).map(|_| rand::random::<char>()).collect();
         ExampleAddressableContent::try_from_content(&RawString::from(s).into()).unwrap()
     }

--- a/crates/holochain_persistence_api/src/cas/storage.rs
+++ b/crates/holochain_persistence_api/src/cas/storage.rs
@@ -7,7 +7,7 @@ use crate::{
     cas::content::{Address, AddressableContent, Content, ExampleAddressableContent},
     eav::{
         Attribute, EavFilter, EaviQuery, EntityAttributeValueIndex, EntityAttributeValueStorage,
-        IndexFilter, ExampleAttribute,
+        IndexFilter,
     },
     error::{PersistenceError, PersistenceResult},
     holochain_json_api::{
@@ -811,9 +811,9 @@ impl EavTestSuite {
     }
 }
 
-pub struct EavBencher;
+pub struct CasBencher;
 
-impl EavBencher {
+impl CasBencher {
 
     fn random_addressable_content() -> ExampleAddressableContent {
         let s: String = (0..4).map(|_| rand::random::<char>()).collect();
@@ -822,35 +822,24 @@ impl EavBencher {
 
     pub fn bench_add(
         b: &mut test::Bencher,
-        mut store: impl EntityAttributeValueStorage<ExampleAttribute> + Clone,
+        mut store: impl ContentAddressableStorage,
     ) {
         b.iter(|| {
-            let eav = EntityAttributeValueIndex::new(
-                &Self::random_addressable_content().address(),
-                &ExampleAttribute::WithPayload("favourite-color".to_string()),
-                &Self::random_addressable_content().address(),
-            )
-            .expect("Could create entityAttributeValue");
-            store.add_eavi(&eav)     
+            store.add(&CasBencher::random_addressable_content())     
         })
     }
 
     pub fn bench_fetch(
         b: &mut test::Bencher,
-        mut store: impl EntityAttributeValueStorage<ExampleAttribute> + Clone,       
+        mut store: impl ContentAddressableStorage,       
     ) {
         // add some values to make it realistic
         for _ in 0..10 {
-            let eav = EntityAttributeValueIndex::new(
-                &Self::random_addressable_content().address(),
-                &ExampleAttribute::WithPayload("favourite-color".to_string()),
-                &Self::random_addressable_content().address(),
-            ).expect("Could create entityAttributeValue");
-            store.add_eavi(&eav).unwrap();
+            store.add(&CasBencher::random_addressable_content()).unwrap();
         }
 
         b.iter(|| {
-            store.fetch_eavi(&EaviQuery::default())     
+            store.fetch(&Address::from("Qm..."))     
         })        
     }
 }

--- a/crates/holochain_persistence_api/src/eav/query.rs
+++ b/crates/holochain_persistence_api/src/eav/query.rs
@@ -154,32 +154,39 @@ impl<'a, A: Attribute> EaviQuery<'a, A> {
 }
 
 /// Represents a filter type which takes in a function to match on
-pub struct EavFilter<'a, T: 'a + Eq>(Box<dyn Fn(T) -> bool + 'a>);
+// pub struct EavFilter<'a, T: 'a + Eq>(Box<dyn Fn(T) -> bool + 'a>);
+pub enum EavFilter<'a, T: 'a + Eq> {
+    Exact(T),
+    Predicate(Box<dyn Fn(T) -> bool + 'a>),
+}
 
 impl<'a, T: 'a + Eq> EavFilter<'a, T> {
     pub fn single(val: T) -> Self {
-        Self(Box::new(move |v| v == val))
+        Self::Exact(val)
     }
 
     pub fn multiple(vals: Vec<T>) -> Self {
-        Self(Box::new(move |val| vals.iter().any(|v| *v == val)))
+        Self::Predicate(Box::new(move |val| vals.iter().any(|v| *v == val)))
     }
 
     pub fn predicate<F>(predicate: F) -> Self
     where
         F: Fn(T) -> bool + 'a,
     {
-        Self(Box::new(predicate))
+        Self::Predicate(Box::new(predicate))
     }
 
-    pub fn check(&self, val: T) -> bool {
-        self.0(val)
+    pub fn check(&self, b: T) -> bool {
+        match self {
+            Self::Exact(a) => a == &b,
+            Self::Predicate(f) => f(b) 
+        }
     }
 }
 
 impl<'a, T: Eq> Default for EavFilter<'a, T> {
     fn default() -> EavFilter<'a, T> {
-        Self(Box::new(|_| true))
+        Self::Predicate(Box::new(|_| true))
     }
 }
 

--- a/crates/holochain_persistence_api/src/eav/query.rs
+++ b/crates/holochain_persistence_api/src/eav/query.rs
@@ -179,7 +179,7 @@ impl<'a, T: 'a + Eq> EavFilter<'a, T> {
     pub fn check(&self, b: T) -> bool {
         match self {
             Self::Exact(a) => a == &b,
-            Self::Predicate(f) => f(b) 
+            Self::Predicate(f) => f(b),
         }
     }
 }

--- a/crates/holochain_persistence_api/src/eav/storage.rs
+++ b/crates/holochain_persistence_api/src/eav/storage.rs
@@ -1,16 +1,9 @@
+use crate::holochain_json_api::json::RawString;
+use cas::content::{AddressableContent, ExampleAddressableContent};
 use eav::{
-    eavi::{
-        EntityAttributeValueIndex,
-        ExampleAttribute,
-    },
-    query::EaviQuery, Attribute, EavFilter, IndexFilter,
-};
-use crate::holochain_json_api::{
-    json::{RawString},
-};
-use cas::content::{
-    ExampleAddressableContent,
-    AddressableContent
+    eavi::{EntityAttributeValueIndex, ExampleAttribute},
+    query::EaviQuery,
+    Attribute, EavFilter, IndexFilter,
 };
 use error::PersistenceResult;
 use objekt;
@@ -116,7 +109,6 @@ pub fn increment_key_till_no_collision<A: Attribute>(
 pub struct EavBencher;
 
 impl EavBencher {
-
     fn random_addressable_content() -> ExampleAddressableContent {
         let s: String = (0..4).map(|_| rand::random::<char>()).collect();
         ExampleAddressableContent::try_from_content(&RawString::from(s).into()).unwrap()
@@ -133,13 +125,13 @@ impl EavBencher {
                 &Self::random_addressable_content().address(),
             )
             .expect("Could create entityAttributeValue");
-            store.add_eavi(&eav)     
+            store.add_eavi(&eav)
         })
     }
 
     pub fn bench_fetch_all(
         b: &mut test::Bencher,
-        mut store: impl EntityAttributeValueStorage<ExampleAttribute>,       
+        mut store: impl EntityAttributeValueStorage<ExampleAttribute>,
     ) {
         // add some values to make it realistic
         for _ in 0..100 {
@@ -147,18 +139,17 @@ impl EavBencher {
                 &Self::random_addressable_content().address(),
                 &ExampleAttribute::WithPayload("favourite-color".to_string()),
                 &Self::random_addressable_content().address(),
-            ).expect("Could create entityAttributeValue");
+            )
+            .expect("Could create entityAttributeValue");
             store.add_eavi(&eav).unwrap();
         }
 
-        b.iter(|| {
-            store.fetch_eavi(&EaviQuery::default())     
-        })        
+        b.iter(|| store.fetch_eavi(&EaviQuery::default()))
     }
 
     pub fn bench_fetch_exact(
         b: &mut test::Bencher,
-        mut store: impl EntityAttributeValueStorage<ExampleAttribute>,       
+        mut store: impl EntityAttributeValueStorage<ExampleAttribute>,
     ) {
         // add some values to make it realistic
         for _ in 0..100 {
@@ -166,7 +157,8 @@ impl EavBencher {
                 &Self::random_addressable_content().address(),
                 &ExampleAttribute::WithPayload("favourite-color".to_string()),
                 &Self::random_addressable_content().address(),
-            ).expect("Could create entityAttributeValue");
+            )
+            .expect("Could create entityAttributeValue");
             store.add_eavi(&eav).unwrap();
         }
 
@@ -175,7 +167,8 @@ impl EavBencher {
             &Self::random_addressable_content().address(),
             &ExampleAttribute::WithPayload("favourite-color".to_string()),
             &Self::random_addressable_content().address(),
-        ).expect("Could create entityAttributeValue");
+        )
+        .expect("Could create entityAttributeValue");
         store.add_eavi(&eav).unwrap();
 
         b.iter(|| {
@@ -185,7 +178,7 @@ impl EavBencher {
                 EavFilter::default(),
                 IndexFilter::LatestByAttribute,
                 None,
-            ))  
-        })        
+            ))
+        })
     }
 }

--- a/crates/holochain_persistence_api/src/hash.rs
+++ b/crates/holochain_persistence_api/src/hash.rs
@@ -63,18 +63,6 @@ impl<'a> TryInto<Vec<u8>> for &'a HashString {
     }
 }
 
-impl From<&[u8]> for HashString {
-    fn from(val: &[u8]) -> Self {
-        HashString::from(String::from_utf8(val.to_vec()).unwrap())
-    }
-}
-
-impl<'a> AsRef<[u8]> for HashString {
-    fn as_ref(&self) -> &[u8] {
-        self.0.as_bytes()
-    }
-}
-
 impl HashString {
     pub fn new() -> HashString {
         HashString("".to_string())

--- a/crates/holochain_persistence_api/src/hash.rs
+++ b/crates/holochain_persistence_api/src/hash.rs
@@ -63,6 +63,18 @@ impl<'a> TryInto<Vec<u8>> for &'a HashString {
     }
 }
 
+impl From<&[u8]> for HashString {
+    fn from(val: &[u8]) -> Self {
+        HashString::from(String::from_utf8(val.to_vec()).unwrap())
+    }
+}
+
+impl<'a> AsRef<[u8]> for HashString {
+    fn as_ref(&self) -> &[u8] {
+        self.0.as_bytes()
+    }
+}
+
 impl HashString {
     pub fn new() -> HashString {
         HashString("".to_string())

--- a/crates/holochain_persistence_api/src/hash.rs
+++ b/crates/holochain_persistence_api/src/hash.rs
@@ -63,12 +63,6 @@ impl<'a> TryInto<Vec<u8>> for &'a HashString {
     }
 }
 
-impl From<&[u8]> for HashString {
-    fn from(val: &[u8]) -> Self {
-        HashString::from(String::from_utf8(val.to_vec()).unwrap())
-    }
-}
-
 impl<'a> AsRef<[u8]> for HashString {
     fn as_ref(&self) -> &[u8] {
         self.0.as_bytes()

--- a/crates/holochain_persistence_api/src/lib.rs
+++ b/crates/holochain_persistence_api/src/lib.rs
@@ -5,7 +5,7 @@
 #![feature(never_type)]
 #![warn(unused_extern_crates)]
 #![feature(test)]
-extern crate test;  
+extern crate test;
 #[macro_use]
 extern crate lazy_static;
 

--- a/crates/holochain_persistence_api/src/lib.rs
+++ b/crates/holochain_persistence_api/src/lib.rs
@@ -4,6 +4,8 @@
 #![feature(try_trait)]
 #![feature(never_type)]
 #![warn(unused_extern_crates)]
+#![feature(test)]
+extern crate test;  
 #[macro_use]
 extern crate lazy_static;
 

--- a/crates/holochain_persistence_lmdb/Cargo.toml
+++ b/crates/holochain_persistence_lmdb/Cargo.toml
@@ -26,6 +26,8 @@ glob = "=0.3.0"
 uuid = { version = "=0.7.1", features = ["v4"] }
 lmdb-zero = "0.4.4"
 pickledb = "=0.4.0"
+bencher = "=0.1.5"
+rand = "0.7.2"
 
 [dev-dependencies]
 tempfile = "=3.0.7"

--- a/crates/holochain_persistence_lmdb/Cargo.toml
+++ b/crates/holochain_persistence_lmdb/Cargo.toml
@@ -27,6 +27,7 @@ uuid = { version = "=0.7.1", features = ["v4"] }
 bencher = "=0.1.5"
 rand = "0.7.2"
 rkv = "0.10.2"
+lmdb-rkv = "0.12.3"
 
 [dev-dependencies]
 tempfile = "=3.0.7"

--- a/crates/holochain_persistence_lmdb/Cargo.toml
+++ b/crates/holochain_persistence_lmdb/Cargo.toml
@@ -28,6 +28,7 @@ lmdb-zero = "0.4.4"
 pickledb = "=0.4.0"
 bencher = "=0.1.5"
 rand = "0.7.2"
+kv = "0.9.2"
 
 [dev-dependencies]
 tempfile = "=3.0.7"

--- a/crates/holochain_persistence_lmdb/Cargo.toml
+++ b/crates/holochain_persistence_lmdb/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name = "holochain_persistence_lmdb"
+version = "0.0.8"
+authors = ["Holochain Core Dev Team <devcore@holochain.org>"]
+edition = "2018"
+description = "persistence for content addressable storage and entity attribute value indexes backed by pickledb-rs."
+keywords = ["holochain", "persistence", "lmdb", "cas", "eav"]
+categories = ["database"]
+license = "Apache-2.0"
+readme = "README.md"
+documentation = "https://docs.rs/holochain_persistence_lmdb"
+repository = "https://github.com/holochain/holochain-persistence"
+
+
+[dependencies]
+serde = "=1.0.89"
+serde_json = { version = "=1.0.39", features = ["preserve_order"] }
+serde_derive = "=1.0.89"
+serde_test = "=1.0.89"
+multihash = "=0.8.0"
+# keep version on the left hand side for release regex
+holochain_persistence_api = { version = "=0.0.8", path = "../holochain_persistence_api" }
+holochain_json_api = "=0.0.17"
+lazy_static = "=1.2.0"
+glob = "=0.3.0"
+uuid = { version = "=0.7.1", features = ["v4"] }
+lmdb-zero = "0.4.4"
+pickledb = "=0.4.0"
+
+[dev-dependencies]
+tempfile = "=3.0.7"

--- a/crates/holochain_persistence_lmdb/Cargo.toml
+++ b/crates/holochain_persistence_lmdb/Cargo.toml
@@ -26,7 +26,6 @@ glob = "=0.3.0"
 uuid = { version = "=0.7.1", features = ["v4"] }
 bencher = "=0.1.5"
 rand = "0.7.2"
-bitflags = "1.2.0"
 rkv = "0.10.2"
 
 [dev-dependencies]

--- a/crates/holochain_persistence_lmdb/Cargo.toml
+++ b/crates/holochain_persistence_lmdb/Cargo.toml
@@ -28,6 +28,8 @@ bencher = "=0.1.5"
 rand = "0.7.2"
 kv = "0.9.2"
 lmdb-rkv = "0.11.4"
+bitflags = "1.2.0"
+rkv = "0.10.2"
 
 [dev-dependencies]
 tempfile = "=3.0.7"

--- a/crates/holochain_persistence_lmdb/Cargo.toml
+++ b/crates/holochain_persistence_lmdb/Cargo.toml
@@ -26,8 +26,6 @@ glob = "=0.3.0"
 uuid = { version = "=0.7.1", features = ["v4"] }
 bencher = "=0.1.5"
 rand = "0.7.2"
-kv = "0.9.2"
-lmdb-rkv = "0.11.4"
 bitflags = "1.2.0"
 rkv = "0.10.2"
 

--- a/crates/holochain_persistence_lmdb/Cargo.toml
+++ b/crates/holochain_persistence_lmdb/Cargo.toml
@@ -24,8 +24,6 @@ holochain_json_api = "=0.0.17"
 lazy_static = "=1.2.0"
 glob = "=0.3.0"
 uuid = { version = "=0.7.1", features = ["v4"] }
-lmdb-zero = "0.4.4"
-pickledb = "=0.4.0"
 bencher = "=0.1.5"
 rand = "0.7.2"
 kv = "0.9.2"

--- a/crates/holochain_persistence_lmdb/Cargo.toml
+++ b/crates/holochain_persistence_lmdb/Cargo.toml
@@ -29,6 +29,7 @@ pickledb = "=0.4.0"
 bencher = "=0.1.5"
 rand = "0.7.2"
 kv = "0.9.2"
+lmdb-rkv = "0.11.4"
 
 [dev-dependencies]
 tempfile = "=3.0.7"

--- a/crates/holochain_persistence_lmdb/README.md
+++ b/crates/holochain_persistence_lmdb/README.md
@@ -1,0 +1,49 @@
+# holochain_persistence_pickle
+
+[![Project](https://img.shields.io/badge/project-holochain-blue.svg?style=flat-square)](http://holochain.org/)
+[![Chat](https://img.shields.io/badge/chat-chat%2eholochain%2enet-blue.svg?style=flat-square)](https://chat.holochain.net)
+
+[![Twitter Follow](https://img.shields.io/twitter/follow/holochain.svg?style=social&label=Follow)](https://twitter.com/holochain)
+
+[![License: Apache-2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://www.apache.org/licenses/LICENSE-2.0)
+
+## Overview
+
+[pickledb](https://github.com/seladb/pickledb-rs) persistence implementation for holochain. Provides content addressable storage (CAS) and entity attribute value (index) using pickledb's key/value store.
+
+## Usage
+Add `holochain_persistence_pickle` crate to your `Cargo.toml`. Below is a stub for creating a storage unit and adding some content.
+
+```rust
+use holochain_persistence_file::cas::pickle::PickleStorage;
+use tempfile::tempdir;
+
+pub fn init() -> PickleStorage {
+  let dir = tempdir().expect("Could not create a tempdir for CAS.");
+  let store = PickleStorage::new(dir.path()).unwrap();
+  store.add(<some_content>).expect("added some content");
+  store
+}
+```
+
+
+## Contribute
+
+Holochain is an open source project.  We welcome all sorts of participation and are actively working on increasing surface area to accept it.  Please see our [contributing guidelines](https://github.com/holochain/org/blob/master/CONTRIBUTING.md) for our general practices and protocols on participating in the community.
+
+## License
+[![License: Apache-2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://www.apache.org/licenses/LICENSE-2.0)
+
+Copyright (C) 2019, Holochain Foundation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+[http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/crates/holochain_persistence_lmdb/README.md
+++ b/crates/holochain_persistence_lmdb/README.md
@@ -1,4 +1,4 @@
-# holochain_persistence_pickle
+# holochain_persistence_lmdb
 
 [![Project](https://img.shields.io/badge/project-holochain-blue.svg?style=flat-square)](http://holochain.org/)
 [![Chat](https://img.shields.io/badge/chat-chat%2eholochain%2enet-blue.svg?style=flat-square)](https://chat.holochain.net)
@@ -9,18 +9,18 @@
 
 ## Overview
 
-[pickledb](https://github.com/seladb/pickledb-rs) persistence implementation for holochain. Provides content addressable storage (CAS) and entity attribute value (index) using pickledb's key/value store.
+[LMDB](http://www.lmdb.tech/doc/index.html) persistence implementation for holochain. Provides content addressable storage (CAS) and entity attribute value (index) using LMDBs's key/value store.
 
 ## Usage
-Add `holochain_persistence_pickle` crate to your `Cargo.toml`. Below is a stub for creating a storage unit and adding some content.
+Add `holochain_persistence_lmdb` crate to your `Cargo.toml`. Below is a stub for creating a storage unit and adding some content.
 
 ```rust
-use holochain_persistence_file::cas::pickle::PickleStorage;
+use holochain_persistence_lmdb::cas::LmdbStorate;
 use tempfile::tempdir;
 
-pub fn init() -> PickleStorage {
+pub fn init() -> LmdbStorate {
   let dir = tempdir().expect("Could not create a tempdir for CAS.");
-  let store = PickleStorage::new(dir.path()).unwrap();
+  let store = LmdbStorate::new(dir.path()).unwrap();
   store.add(<some_content>).expect("added some content");
   store
 }

--- a/crates/holochain_persistence_lmdb/README.md
+++ b/crates/holochain_persistence_lmdb/README.md
@@ -15,7 +15,7 @@
 Add `holochain_persistence_lmdb` crate to your `Cargo.toml`. Below is a stub for creating a storage unit and adding some content.
 
 ```rust
-use holochain_persistence_lmdb::cas::LmdbStorate;
+use holochain_persistence_lmdb::cas::LmdbStorage;
 use tempfile::tempdir;
 
 pub fn init() -> LmdbStorate {

--- a/crates/holochain_persistence_lmdb/README.md
+++ b/crates/holochain_persistence_lmdb/README.md
@@ -18,7 +18,7 @@ Add `holochain_persistence_lmdb` crate to your `Cargo.toml`. Below is a stub for
 use holochain_persistence_lmdb::cas::LmdbStorage;
 use tempfile::tempdir;
 
-pub fn init() -> LmdbStorate {
+pub fn init() -> LmdbStorage {
   let dir = tempdir().expect("Could not create a tempdir for CAS.");
   let store = LmdbStorate::new(dir.path()).unwrap();
   store.add(<some_content>).expect("added some content");

--- a/crates/holochain_persistence_lmdb/src/cas/lmdb.rs
+++ b/crates/holochain_persistence_lmdb/src/cas/lmdb.rs
@@ -1,0 +1,162 @@
+use holochain_persistence_api::{
+    cas::{
+        content::{Address, AddressableContent, Content},
+        storage::ContentAddressableStorage,
+    },
+    error::{PersistenceResult, PersistenceError},
+    reporting::{ReportStorage, StorageReport},
+};
+use holochain_json_api::json::JsonString;
+use lmdb_zero as lmdb;
+use lmdb_zero::error::Error as LmdbError;
+use std::{
+    fmt::{Debug, Error, Formatter},
+    path::Path,
+    sync::{Arc},
+};
+use uuid::Uuid;
+
+#[derive(Clone)]
+pub struct LmdbStorage {
+    id: Uuid,
+    db: Arc<lmdb::Database<'static>>,
+    env: Arc<lmdb::Environment>,
+}
+
+impl Debug for LmdbStorage {
+    fn fmt(&self, f: &mut Formatter) -> Result<(), Error> {
+        f.debug_struct("LmdbStorage")
+            .field("id", &self.id)
+            .finish()
+    }
+}
+
+impl LmdbStorage {
+    pub fn new<P: AsRef<Path> + Clone>(db_path: P) -> LmdbStorage {
+        let cas_db_path = db_path.as_ref().join("cas").with_extension("db");
+        std::fs::create_dir_all(cas_db_path.clone()).unwrap();
+        let env_wrap = unsafe {
+            lmdb::EnvBuilder::new().unwrap().open(
+                cas_db_path.to_str().unwrap(),
+                lmdb::open::Flags::empty(),
+                0o600
+            ).unwrap()
+        };
+        let env = Arc::new(env_wrap);
+
+        let db = lmdb::Database::open(
+            env.clone(),
+            None,
+            &lmdb::DatabaseOptions::defaults()
+        ).unwrap();
+
+        LmdbStorage {
+            id: Uuid::new_v4(),
+            db: Arc::new(db),
+            env,
+        }
+    }
+}
+
+impl ContentAddressableStorage for LmdbStorage {
+    fn add(&mut self, content: &dyn AddressableContent) -> PersistenceResult<()> {        
+        let txn = lmdb::WriteTransaction::new(self.env.clone()).unwrap();
+        // An accessor is used to control memory access.
+        // NB You can only have one live accessor from a particular transaction
+        // at a time. Violating this results in a panic at runtime.
+        {
+            let mut access = txn.access();
+            access.put(
+                &self.db,
+                content.address().to_string().as_bytes(), // TODO: Actually handle this conversion properly
+                content.content().to_string().as_bytes(),
+                lmdb::put::Flags::empty()
+            ).unwrap();
+        }
+        // Commit the changes so they are visible to later transactions
+        txn.commit().unwrap();
+
+        Ok(())
+    }
+
+    // TODO: optimize this to not do a full read
+    fn contains(&self, address: &Address) -> PersistenceResult<bool> {
+        let txn = lmdb::ReadTransaction::new(self.env.clone()).unwrap();
+        let access = txn.access();
+        let get_result = access.get::<_, str>(&self.db, address.to_string().as_bytes());
+        match get_result {
+            Ok(_) => Ok(true),
+            Err(LmdbError::Code(-30798)) => Ok(false), // This is the code for `value not found`
+            Err(e) => Err(PersistenceError::new(&format!("{:?}", e)))
+        }
+    }
+
+    fn fetch(&self, address: &Address) -> PersistenceResult<Option<Content>> {
+        let txn = lmdb::ReadTransaction::new(self.env.clone()).unwrap();
+        let access = txn.access();
+        let get_result = access.get::<_, str>(&self.db, address.to_string().as_bytes());
+        match get_result {
+            Ok(result) => Ok(Some(JsonString::from_json(result))),
+            Err(LmdbError::Code(-30798)) => Ok(None), // This is the code for `value not found`
+            Err(e) => Err(PersistenceError::new(&format!("{:?}", e)))
+        }
+    }
+
+    fn get_id(&self) -> Uuid {
+        self.id
+    }
+}
+
+impl ReportStorage for LmdbStorage {
+    fn get_storage_report(&self) -> PersistenceResult<StorageReport> {
+        Ok(StorageReport::new(0)) // TODO: implement this
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::cas::lmdb::LmdbStorage;
+    use holochain_json_api::json::RawString;
+    use holochain_persistence_api::{
+        cas::{
+            content::{Content, ExampleAddressableContent, OtherExampleAddressableContent},
+            storage::{ContentAddressableStorage, StorageTestSuite},
+        },
+        reporting::{ReportStorage, StorageReport},
+    };
+    use tempfile::{tempdir, TempDir};
+
+    pub fn test_lmdb_cas() -> (LmdbStorage, TempDir) {
+        let dir = tempdir().expect("Could not create a tempdir for CAS testing");
+        (LmdbStorage::new(dir.path()), dir)
+    }
+
+    #[test]
+    /// show that content of different types can round trip through the same storage
+    /// this is copied straight from the example with a file CAS
+    fn lmdb_content_round_trip_test() {
+        let (cas, _dir) = test_lmdb_cas();
+        let test_suite = StorageTestSuite::new(cas);
+        test_suite.round_trip_test::<ExampleAddressableContent, OtherExampleAddressableContent>(
+            RawString::from("foo").into(),
+            RawString::from("bar").into(),
+        );
+    }
+
+    #[test]
+    fn lmdb_report_storage_test() {
+        let (mut cas, _) = test_lmdb_cas();
+        // add some content
+        cas.add(&Content::from_json("some bytes"))
+            .expect("could not add to CAS");
+        assert_eq!(cas.get_storage_report().unwrap(), StorageReport::new(0),);
+
+        // add some more
+        cas.add(&Content::from_json("more bytes"))
+            .expect("could not add to CAS");
+        assert_eq!(
+            cas.get_storage_report().unwrap(),
+            StorageReport::new(0 + 0),
+        );
+    }
+}

--- a/crates/holochain_persistence_lmdb/src/cas/lmdb.rs
+++ b/crates/holochain_persistence_lmdb/src/cas/lmdb.rs
@@ -1,3 +1,4 @@
+use crate::common::LmdbInstance;
 use holochain_json_api::json::JsonString;
 use holochain_persistence_api::{
     cas::{
@@ -8,14 +9,14 @@ use holochain_persistence_api::{
     reporting::{ReportStorage, StorageReport},
 };
 use rkv::{
-    error::{DataError, StoreError}, Value,
+    error::{DataError, StoreError},
+    Value,
 };
 use std::{
     fmt::{Debug, Error, Formatter},
     path::Path,
 };
 use uuid::Uuid;
-use crate::common::LmdbInstance;
 
 const CAS_BUCKET: &str = "cas";
 
@@ -32,7 +33,10 @@ impl Debug for LmdbStorage {
 }
 
 impl LmdbStorage {
-    pub fn new<P: AsRef<Path> + Clone>(db_path: P, initial_map_bytes: Option<usize>) -> LmdbStorage {
+    pub fn new<P: AsRef<Path> + Clone>(
+        db_path: P,
+        initial_map_bytes: Option<usize>,
+    ) -> LmdbStorage {
         LmdbStorage {
             id: Uuid::new_v4(),
             lmdb: LmdbInstance::new(CAS_BUCKET, db_path, initial_map_bytes),

--- a/crates/holochain_persistence_lmdb/src/cas/lmdb.rs
+++ b/crates/holochain_persistence_lmdb/src/cas/lmdb.rs
@@ -16,7 +16,7 @@ use std::{
 use uuid::Uuid;
 
 const CAS_BUCKET: &str = "cas";
-const MAX_SIZE_BYTES: usize = 104857600; // TODO: Discuss what this should be
+const MAX_SIZE_BYTES: usize = 104857600; // TODO: Discuss what this should be, currently 100MB
 
 #[derive(Clone)]
 pub struct LmdbStorage {

--- a/crates/holochain_persistence_lmdb/src/cas/lmdb.rs
+++ b/crates/holochain_persistence_lmdb/src/cas/lmdb.rs
@@ -78,7 +78,7 @@ impl LmdbStorage {
 
     fn lmdb_fetch(&self, address: &Address) -> Result<Option<Content>, KvError> {
         let store = self.store.read()?;
-        let bucket = store.bucket::<Address, String>(Some("cas")).unwrap();
+        let bucket = store.bucket::<Address, String>(Some(CAS_BUCKET)).unwrap();
         let txn = store.read_txn().unwrap();
 
         match txn.get(&bucket, address.clone()) {

--- a/crates/holochain_persistence_lmdb/src/cas/lmdb.rs
+++ b/crates/holochain_persistence_lmdb/src/cas/lmdb.rs
@@ -19,7 +19,7 @@ use std::{
 use uuid::Uuid;
 
 const CAS_BUCKET: &str = "cas";
-const MAX_SIZE_BYTES: usize = 104857600; // TODO: Discuss what this should be, currently 100MB
+const INITIAL_SIZE_BYTES: usize = 104857600; // TODO: Discuss what this should be, currently 100MB
 
 #[derive(Clone)]
 pub struct LmdbStorage {
@@ -47,7 +47,7 @@ impl LmdbStorage {
                 let mut env_builder = Rkv::environment_builder();
                 env_builder
                     // max size of memory map, can be changed later
-                    .set_map_size(MAX_SIZE_BYTES)
+                    .set_map_size(INITIAL_SIZE_BYTES)
                     // max number of DBs in this environment
                     .set_max_dbs(1)
                     // Thes flags make writes waaaaay faster by async writing to disk rather than blocking

--- a/crates/holochain_persistence_lmdb/src/cas/lmdb.rs
+++ b/crates/holochain_persistence_lmdb/src/cas/lmdb.rs
@@ -46,18 +46,10 @@ impl LmdbStorage {
 
 impl LmdbStorage {
     fn lmdb_add(&mut self, content: &dyn AddressableContent) -> Result<(), StoreError> {
-        let env = self.lmdb.manager.read().unwrap();
-        let mut writer = env.write()?;
-
-        self.lmdb.store.put(
-            &mut writer,
+        self.lmdb.add(
             content.address(),
-            &Value::Str(&content.content().to_string()),
-        )?;
-
-        writer.commit()?;
-
-        Ok(())
+            &Value::Json(&content.content().to_string()),
+        )
     }
 
     fn lmdb_fetch(&self, address: &Address) -> Result<Option<Content>, StoreError> {
@@ -66,7 +58,7 @@ impl LmdbStorage {
 
         match self.lmdb.store.get(&reader, address.clone()) {
             Ok(Some(value)) => match value {
-                Value::Str(s) => Ok(Some(JsonString::from_json(s))),
+                Value::Json(s) => Ok(Some(JsonString::from_json(s))),
                 _ => Err(StoreError::DataError(DataError::Empty)),
             },
             Ok(None) => Ok(None),

--- a/crates/holochain_persistence_lmdb/src/cas/mod.rs
+++ b/crates/holochain_persistence_lmdb/src/cas/mod.rs
@@ -1,0 +1,1 @@
+pub mod lmdb;

--- a/crates/holochain_persistence_lmdb/src/common.rs
+++ b/crates/holochain_persistence_lmdb/src/common.rs
@@ -1,4 +1,4 @@
-use rkv::{DatabaseFlags, EnvironmentFlags, Manager, Rkv, SingleStore, StoreOptions};
+use rkv::{DatabaseFlags, EnvironmentFlags, Manager, Rkv, SingleStore, StoreOptions, StoreError, Value};
 use std::{
     path::Path,
     sync::{Arc, RwLock},
@@ -55,5 +55,17 @@ impl LmdbInstance {
             store: store,
             manager: manager.clone(),
         }
+    }
+
+    pub fn add<K: AsRef<[u8]>>(&self, key: K, value: &Value) -> Result<(), StoreError> {
+        let env = self.manager.read().unwrap();
+        let mut writer = env.write()?;
+        self.store.put(
+            &mut writer,
+            key,
+            value,
+        )?;
+        writer.commit()?;
+        Ok(())
     }
 }

--- a/crates/holochain_persistence_lmdb/src/common.rs
+++ b/crates/holochain_persistence_lmdb/src/common.rs
@@ -78,6 +78,7 @@ impl LmdbInstance {
         Ok(())
     }
 
+    #[allow(dead_code)]
     pub fn info(&self) -> Result<rkv::Info, StoreError> {
         self.manager.read().unwrap().info()
     }

--- a/crates/holochain_persistence_lmdb/src/common.rs
+++ b/crates/holochain_persistence_lmdb/src/common.rs
@@ -1,10 +1,11 @@
 use rkv::{DatabaseFlags, EnvironmentFlags, Manager, Rkv, SingleStore, StoreOptions, StoreError, Value};
+use lmdb::Error as LmdbError;
 use std::{
     path::Path,
     sync::{Arc, RwLock},
 };
 
-const DEFAULT_INITIAL_MAP_BYTES: usize = 104857600;
+const DEFAULT_INITIAL_MAP_BYTES: usize = 100*1024*1024;
 
 #[derive(Clone)]
 pub(crate) struct LmdbInstance {
@@ -57,15 +58,69 @@ impl LmdbInstance {
         }
     }
 
-    pub fn add<K: AsRef<[u8]>>(&self, key: K, value: &Value) -> Result<(), StoreError> {
+    pub fn add<K: AsRef<[u8]> + Clone>(&self, key: K, value: &Value) -> Result<(), StoreError> {
         let env = self.manager.read().unwrap();
         let mut writer = env.write()?;
+
         self.store.put(
             &mut writer,
-            key,
+            key.clone(),
             value,
         )?;
-        writer.commit()?;
+
+        match writer.commit() {
+            Err(StoreError::LmdbError(LmdbError::MapFull)) => {
+                // double the mmap and then try again
+                let map_size = env.info()?.map_size();
+                env.set_map_size(map_size*2)?;
+                self.add(key, value)           
+            },
+            r => r, // preserve any other errors
+        }?;
         Ok(())
+    }
+
+    pub fn info(&self) -> Result<rkv::Info, StoreError> {
+        self.manager.read().unwrap().info()
+    }
+}
+
+#[cfg(test)]
+pub mod tests {
+    use super::*;
+    use tempfile::tempdir;
+    use holochain_persistence_api::cas::{
+        content::AddressableContent,
+        storage::CasBencher
+    };
+
+    #[test]
+    fn can_grow_map_on_write() {
+        // make a db with a 1MB MMAP. This seems to be the lowest you an go (probably OS dependent)
+        let inititial_mmap_size = 1024*1024;
+        let dir = tempdir().expect("Could not create a tempdir for CAS testing");
+        let lmdb = LmdbInstance::new("can_grow_map_on_write", dir.path(), Some(inititial_mmap_size));
+        
+        // put data in there until the mmap size changes
+        while lmdb.info().unwrap().map_size() == inititial_mmap_size {
+            let content = CasBencher::random_addressable_content();
+            lmdb.add(content.address(), &Value::Json(&content.content().to_string())).unwrap();
+        }
+
+        assert_eq!(
+            lmdb.info().unwrap().map_size(),
+            inititial_mmap_size*2,
+        );
+
+        // Do it again for good measure
+        while lmdb.info().unwrap().map_size() == 2*inititial_mmap_size {
+            let content = CasBencher::random_addressable_content();
+            lmdb.add(content.address(), &Value::Json(&content.content().to_string())).unwrap();
+        }
+
+        assert_eq!(
+            lmdb.info().unwrap().map_size(),
+            inititial_mmap_size*4,
+        );
     }
 }

--- a/crates/holochain_persistence_lmdb/src/common.rs
+++ b/crates/holochain_persistence_lmdb/src/common.rs
@@ -1,6 +1,4 @@
-use rkv::{
-    DatabaseFlags, EnvironmentFlags, Manager, Rkv, SingleStore, StoreOptions,
-};
+use rkv::{DatabaseFlags, EnvironmentFlags, Manager, Rkv, SingleStore, StoreOptions};
 use std::{
     path::Path,
     sync::{Arc, RwLock},
@@ -10,17 +8,20 @@ const DEFAULT_INITIAL_MAP_BYTES: usize = 104857600;
 
 #[derive(Clone)]
 pub(crate) struct LmdbInstance {
-	pub store: SingleStore,
-	pub manager: Arc<RwLock<Rkv>>
+    pub store: SingleStore,
+    pub manager: Arc<RwLock<Rkv>>,
 }
 
 impl LmdbInstance {
-	pub fn new<P: AsRef<Path> + Clone>(db_name: &str, path: P, initial_map_bytes: Option<usize>) -> LmdbInstance {
-		let db_path = path.as_ref().join(db_name).with_extension("db");
-        std::fs::create_dir_all(db_path.clone())
-            .expect("Could not create file path for store");
+    pub fn new<P: AsRef<Path> + Clone>(
+        db_name: &str,
+        path: P,
+        initial_map_bytes: Option<usize>,
+    ) -> LmdbInstance {
+        let db_path = path.as_ref().join(db_name).with_extension("db");
+        std::fs::create_dir_all(db_path.clone()).expect("Could not create file path for store");
 
-		let manager = Manager::singleton()
+        let manager = Manager::singleton()
             .write()
             .unwrap()
             .get_or_create(db_path.as_path(), |path: &Path| {
@@ -54,5 +55,5 @@ impl LmdbInstance {
             store: store,
             manager: manager.clone(),
         }
-	}
+    }
 }

--- a/crates/holochain_persistence_lmdb/src/common.rs
+++ b/crates/holochain_persistence_lmdb/src/common.rs
@@ -1,0 +1,58 @@
+use rkv::{
+    DatabaseFlags, EnvironmentFlags, Manager, Rkv, SingleStore, StoreOptions,
+};
+use std::{
+    path::Path,
+    sync::{Arc, RwLock},
+};
+
+const DEFAULT_INITIAL_MAP_BYTES: usize = 104857600;
+
+#[derive(Clone)]
+pub(crate) struct LmdbInstance {
+	pub store: SingleStore,
+	pub manager: Arc<RwLock<Rkv>>
+}
+
+impl LmdbInstance {
+	pub fn new<P: AsRef<Path> + Clone>(db_name: &str, path: P, initial_map_bytes: Option<usize>) -> LmdbInstance {
+		let db_path = path.as_ref().join(db_name).with_extension("db");
+        std::fs::create_dir_all(db_path.clone())
+            .expect("Could not create file path for store");
+
+		let manager = Manager::singleton()
+            .write()
+            .unwrap()
+            .get_or_create(db_path.as_path(), |path: &Path| {
+                let mut env_builder = Rkv::environment_builder();
+                env_builder
+                    // max size of memory map, can be changed later
+                    .set_map_size(initial_map_bytes.unwrap_or(DEFAULT_INITIAL_MAP_BYTES))
+                    // max number of DBs in this environment
+                    .set_max_dbs(1)
+                    // Thes flags make writes waaaaay faster by async writing to disk rather than blocking
+                    // There is some loss of data integrity guarantees that comes with this
+                    .set_flags(EnvironmentFlags::WRITE_MAP | EnvironmentFlags::MAP_ASYNC);
+                Rkv::from_env(path, env_builder)
+            })
+            .expect("Could not create the environment");
+
+        let env = manager
+            .read()
+            .expect("Could not get a read lock on the manager");
+
+        // Then you can use the environment handle to get a handle to a datastore:
+        let options = StoreOptions {
+            create: true,
+            flags: DatabaseFlags::empty(),
+        };
+        let store: SingleStore = env
+            .open_single(db_name, options)
+            .expect("Could not create store");
+
+        LmdbInstance {
+            store: store,
+            manager: manager.clone(),
+        }
+	}
+}

--- a/crates/holochain_persistence_lmdb/src/eav/lmdb.rs
+++ b/crates/holochain_persistence_lmdb/src/eav/lmdb.rs
@@ -119,14 +119,16 @@ pub mod tests {
     use holochain_persistence_api::{
         cas::{
             content::{AddressableContent, ExampleAddressableContent},
-            storage::EavTestSuite,
+            storage::{EavTestSuite, EavBencher},
         },
-        eav::ExampleAttribute,
+        eav::{
+            Attribute, ExampleAttribute,
+        },
     };
     use tempfile::tempdir;
 
     #[test]
-    fn pickle_eav_round_trip() {
+    fn lmdb_eav_round_trip() {
         let temp = tempdir().expect("test was supposed to create temp dir");
 
         let temp_path = String::from(temp.path().to_str().expect("temp dir could not be string"));
@@ -144,8 +146,26 @@ pub mod tests {
         )
     }
 
+    fn new_store<A: Attribute>() -> EavLmdbStorage<A> {
+        let temp = tempdir().expect("test was supposed to create temp dir");
+        let temp_path = String::from(temp.path().to_str().expect("temp dir could not be string"));
+        EavLmdbStorage::new(temp_path)
+    }
+
+    #[bench]
+    fn bench_lmdb_add(b: &mut test::Bencher) {
+        let store = new_store();
+        EavBencher::bench_add(b, store);
+    }
+
+    #[bench]
+    fn bench_lmdb_fetch(b: &mut test::Bencher) {
+        let store = new_store();
+        EavBencher::bench_fetch(b, store);        
+    }
+
     #[test]
-    fn pickle_eav_one_to_many() {
+    fn lmdb_eav_one_to_many() {
         let temp = tempdir().expect("test was supposed to create temp dir");
         let temp_path = String::from(temp.path().to_str().expect("temp dir could not be string"));
         let eav_storage = EavLmdbStorage::new(temp_path);
@@ -157,7 +177,7 @@ pub mod tests {
     }
 
     #[test]
-    fn pickle_eav_many_to_one() {
+    fn lmdb_eav_many_to_one() {
         let temp = tempdir().expect("test was supposed to create temp dir");
         let temp_path = String::from(temp.path().to_str().expect("temp dir could not be string"));
         let eav_storage = EavLmdbStorage::new(temp_path);
@@ -169,7 +189,7 @@ pub mod tests {
     }
 
     #[test]
-    fn pickle_eav_range() {
+    fn lmdb_eav_range() {
         let temp = tempdir().expect("test was supposed to create temp dir");
         let temp_path = String::from(temp.path().to_str().expect("temp dir could not be string"));
         let eav_storage = EavLmdbStorage::new(temp_path);
@@ -181,7 +201,7 @@ pub mod tests {
     }
 
     #[test]
-    fn pickle_eav_prefixes() {
+    fn lmdb_eav_prefixes() {
         let temp = tempdir().expect("test was supposed to create temp dir");
         let temp_path = String::from(temp.path().to_str().expect("temp dir could not be string"));
         let eav_storage = EavLmdbStorage::new(temp_path);
@@ -199,7 +219,7 @@ pub mod tests {
     }
 
     #[test]
-    fn pickle_tombstone() {
+    fn lmdb_tombstone() {
         let temp = tempdir().expect("test was supposed to create temp dir");
         let temp_path = String::from(temp.path().to_str().expect("temp dir could not be string"));
         let eav_storage = EavLmdbStorage::new(temp_path);

--- a/crates/holochain_persistence_lmdb/src/eav/lmdb.rs
+++ b/crates/holochain_persistence_lmdb/src/eav/lmdb.rs
@@ -129,10 +129,10 @@ pub mod tests {
     use holochain_persistence_api::{
         cas::{
             content::{AddressableContent, ExampleAddressableContent},
-            storage::{EavTestSuite, EavBencher},
+            storage::{EavTestSuite},
         },
         eav::{
-            Attribute, ExampleAttribute,
+            Attribute, ExampleAttribute, storage::EavBencher,
         },
     };
     use tempfile::tempdir;

--- a/crates/holochain_persistence_lmdb/src/eav/lmdb.rs
+++ b/crates/holochain_persistence_lmdb/src/eav/lmdb.rs
@@ -21,7 +21,7 @@ use std::{
 use uuid::Uuid;
 
 const EAV_BUCKET: &str = "EAV";
-const MAX_SIZE_BYTES: usize = 104857600; // TODO: Discuss what this should be, currently 100MB
+const INITIAL_SIZE_BYTES: usize = 104857600; // TODO: Discuss what this should be, currently 100MB
 
 #[derive(Clone)]
 pub struct EavLmdbStorage<A: Attribute> {
@@ -34,7 +34,7 @@ pub struct EavLmdbStorage<A: Attribute> {
 impl<A: Attribute> EavLmdbStorage<A> {
     pub fn new<P: AsRef<Path> + Clone>(db_path: P) -> EavLmdbStorage<A> {
         let eav_db_path = db_path.as_ref().join("eav").with_extension("db");
-        std::fs::create_dir_all(cas_db_path.clone())
+        std::fs::create_dir_all(eav_db_path.clone())
             .expect("Could not create file path for CAS store");
 
         let manager = Manager::singleton()
@@ -44,7 +44,7 @@ impl<A: Attribute> EavLmdbStorage<A> {
                 let mut env_builder = Rkv::environment_builder();
                 env_builder
                     // max size of memory map, can be changed later
-                    .set_map_size(MAX_SIZE_BYTES)
+                    .set_map_size(INITIAL_SIZE_BYTES)
                     // max number of DBs in this environment
                     .set_max_dbs(1)
                     // Thes flags make writes waaaaay faster by async writing to disk rather than blocking

--- a/crates/holochain_persistence_lmdb/src/eav/lmdb.rs
+++ b/crates/holochain_persistence_lmdb/src/eav/lmdb.rs
@@ -33,7 +33,7 @@ pub struct EavLmdbStorage<A: Attribute> {
 
 impl<A: Attribute> EavLmdbStorage<A> {
     pub fn new<P: AsRef<Path> + Clone>(db_path: P) -> EavLmdbStorage<A> {
-        let cas_db_path = db_path.as_ref().join("eav").with_extension("db");
+        let eav_db_path = db_path.as_ref().join("eav").with_extension("db");
         std::fs::create_dir_all(cas_db_path.clone())
             .expect("Could not create file path for CAS store");
 

--- a/crates/holochain_persistence_lmdb/src/eav/lmdb.rs
+++ b/crates/holochain_persistence_lmdb/src/eav/lmdb.rs
@@ -40,7 +40,7 @@ impl<A: Attribute> EavLmdbStorage<A> {
         let manager = Manager::singleton()
             .write()
             .unwrap()
-            .get_or_create(cas_db_path.as_path(), |path: &Path| {
+            .get_or_create(eav_db_path.as_path(), |path: &Path| {
                 let mut env_builder = Rkv::environment_builder();
                 env_builder
                     // max size of memory map, can be changed later

--- a/crates/holochain_persistence_lmdb/src/eav/lmdb.rs
+++ b/crates/holochain_persistence_lmdb/src/eav/lmdb.rs
@@ -55,18 +55,10 @@ where
         &mut self,
         eav: &EntityAttributeValueIndex<A>,
     ) -> Result<Option<EntityAttributeValueIndex<A>>, StoreError> {
-        let env = self.lmdb.manager.read().unwrap();
-        let mut writer = env.write()?;
-
         // use a clever key naming scheme to speed up exact match queries on the entity
         let key = format!("{}::{}", eav.entity(), eav.index());
-
         self.lmdb
-            .store
-            .put(&mut writer, key, &Value::Json(&eav.content().to_string()))?;
-
-        writer.commit()?;
-
+            .add(key, &Value::Json(&eav.content().to_string()))?;
         Ok(Some(eav.clone()))
     }
 

--- a/crates/holochain_persistence_lmdb/src/eav/mod.rs
+++ b/crates/holochain_persistence_lmdb/src/eav/mod.rs
@@ -1,0 +1,1 @@
+pub mod lmdb;

--- a/crates/holochain_persistence_lmdb/src/lib.rs
+++ b/crates/holochain_persistence_lmdb/src/lib.rs
@@ -9,5 +9,6 @@
 #[allow(unused_extern_crates)]
 extern crate test;
 
+mod common;
 pub mod cas;
 pub mod eav;

--- a/crates/holochain_persistence_lmdb/src/lib.rs
+++ b/crates/holochain_persistence_lmdb/src/lib.rs
@@ -9,6 +9,6 @@
 #[allow(unused_extern_crates)]
 extern crate test;
 
-mod common;
 pub mod cas;
+mod common;
 pub mod eav;

--- a/crates/holochain_persistence_lmdb/src/lib.rs
+++ b/crates/holochain_persistence_lmdb/src/lib.rs
@@ -6,6 +6,7 @@
 //! which are defined but not implemented in the core_types crate.
 #![warn(unused_extern_crates)]
 #![feature(test)]
+#[allow(unused_extern_crates)]
 extern crate test;   
 
 pub mod cas;

--- a/crates/holochain_persistence_lmdb/src/lib.rs
+++ b/crates/holochain_persistence_lmdb/src/lib.rs
@@ -1,0 +1,10 @@
+//! CAS Implementations
+//!
+//! (CAS == Content Addressable Storage)
+//!
+//! This crate contains implementations for the CAS and EAV traits
+//! which are defined but not implemented in the core_types crate.
+#![warn(unused_extern_crates)]
+
+pub mod cas;
+pub mod eav;

--- a/crates/holochain_persistence_lmdb/src/lib.rs
+++ b/crates/holochain_persistence_lmdb/src/lib.rs
@@ -7,7 +7,7 @@
 #![warn(unused_extern_crates)]
 #![feature(test)]
 #[allow(unused_extern_crates)]
-extern crate test;   
+extern crate test;
 
 pub mod cas;
 pub mod eav;

--- a/crates/holochain_persistence_lmdb/src/lib.rs
+++ b/crates/holochain_persistence_lmdb/src/lib.rs
@@ -5,6 +5,8 @@
 //! This crate contains implementations for the CAS and EAV traits
 //! which are defined but not implemented in the core_types crate.
 #![warn(unused_extern_crates)]
+#![feature(test)]
+extern crate test;   
 
 pub mod cas;
 pub mod eav;

--- a/crates/holochain_persistence_pickle/src/cas/pickle.rs
+++ b/crates/holochain_persistence_pickle/src/cas/pickle.rs
@@ -102,9 +102,9 @@ mod tests {
     use holochain_persistence_api::{
         cas::{
             content::{Content, ExampleAddressableContent, OtherExampleAddressableContent},
-            storage::{ContentAddressableStorage, StorageTestSuite, CasBencher},
+            storage::{CasBencher, ContentAddressableStorage, StorageTestSuite},
         },
-        reporting::{ReportStorage, StorageReport, },
+        reporting::{ReportStorage, StorageReport},
     };
     use tempfile::{tempdir, TempDir};
 
@@ -122,7 +122,7 @@ mod tests {
     #[bench]
     fn bench_pickle_cas_fetch(b: &mut test::Bencher) {
         let (store, _) = test_pickle_cas();
-        CasBencher::bench_fetch(b, store);        
+        CasBencher::bench_fetch(b, store);
     }
 
     #[test]

--- a/crates/holochain_persistence_pickle/src/cas/pickle.rs
+++ b/crates/holochain_persistence_pickle/src/cas/pickle.rs
@@ -102,15 +102,27 @@ mod tests {
     use holochain_persistence_api::{
         cas::{
             content::{Content, ExampleAddressableContent, OtherExampleAddressableContent},
-            storage::{ContentAddressableStorage, StorageTestSuite},
+            storage::{ContentAddressableStorage, StorageTestSuite, CasBencher},
         },
-        reporting::{ReportStorage, StorageReport},
+        reporting::{ReportStorage, StorageReport, },
     };
     use tempfile::{tempdir, TempDir};
 
     pub fn test_pickle_cas() -> (PickleStorage, TempDir) {
         let dir = tempdir().expect("Could not create a tempdir for CAS testing");
         (PickleStorage::new(dir.path()), dir)
+    }
+
+    #[bench]
+    fn bench_pickle_cas_add(b: &mut test::Bencher) {
+        let (store, _) = test_pickle_cas();
+        CasBencher::bench_add(b, store);
+    }
+
+    #[bench]
+    fn bench_pickle_cas_fetch(b: &mut test::Bencher) {
+        let (store, _) = test_pickle_cas();
+        CasBencher::bench_fetch(b, store);        
     }
 
     #[test]

--- a/crates/holochain_persistence_pickle/src/eav/pickle.rs
+++ b/crates/holochain_persistence_pickle/src/eav/pickle.rs
@@ -135,6 +135,12 @@ pub mod tests {
     }
 
     #[bench]
+    fn bench_pickle_eav_add(b: &mut test::Bencher) {
+        let store = new_store();
+        EavBencher::bench_add(b, store);        
+    }
+
+    #[bench]
     fn bench_pickle_eav_fetch_all(b: &mut test::Bencher) {
         let store = new_store();
         EavBencher::bench_fetch_all(b, store);        

--- a/crates/holochain_persistence_pickle/src/eav/pickle.rs
+++ b/crates/holochain_persistence_pickle/src/eav/pickle.rs
@@ -122,9 +122,9 @@ pub mod tests {
     use holochain_persistence_api::{
         cas::{
             content::{AddressableContent, ExampleAddressableContent},
-            storage::{EavTestSuite, EavBencher}
+            storage::{EavTestSuite}
         },
-        eav::{ExampleAttribute, Attribute},
+        eav::{ExampleAttribute, Attribute, EavBencher},
     };
     use tempfile::tempdir;
 
@@ -135,13 +135,13 @@ pub mod tests {
     }
 
     #[bench]
-    fn bench_pickle_add(b: &mut test::Bencher) {
+    fn bench_pickle_eav_add(b: &mut test::Bencher) {
         let store = new_store();
         EavBencher::bench_add(b, store);
     }
 
     #[bench]
-    fn bench_pickle_fetch(b: &mut test::Bencher) {
+    fn bench_pickle_eav_fetch(b: &mut test::Bencher) {
         let store = new_store();
         EavBencher::bench_fetch(b, store);        
     }

--- a/crates/holochain_persistence_pickle/src/eav/pickle.rs
+++ b/crates/holochain_persistence_pickle/src/eav/pickle.rs
@@ -122,9 +122,9 @@ pub mod tests {
     use holochain_persistence_api::{
         cas::{
             content::{AddressableContent, ExampleAddressableContent},
-            storage::{EavTestSuite}
+            storage::EavTestSuite,
         },
-        eav::{ExampleAttribute, Attribute, EavBencher},
+        eav::{Attribute, EavBencher, ExampleAttribute},
     };
     use tempfile::tempdir;
 
@@ -137,19 +137,19 @@ pub mod tests {
     #[bench]
     fn bench_pickle_eav_add(b: &mut test::Bencher) {
         let store = new_store();
-        EavBencher::bench_add(b, store);        
+        EavBencher::bench_add(b, store);
     }
 
     #[bench]
     fn bench_pickle_eav_fetch_all(b: &mut test::Bencher) {
         let store = new_store();
-        EavBencher::bench_fetch_all(b, store);        
+        EavBencher::bench_fetch_all(b, store);
     }
 
     #[bench]
     fn bench_pickle_eav_fetch_exact(b: &mut test::Bencher) {
         let store = new_store();
-        EavBencher::bench_fetch_exact(b, store);        
+        EavBencher::bench_fetch_exact(b, store);
     }
 
     #[test]

--- a/crates/holochain_persistence_pickle/src/eav/pickle.rs
+++ b/crates/holochain_persistence_pickle/src/eav/pickle.rs
@@ -122,11 +122,29 @@ pub mod tests {
     use holochain_persistence_api::{
         cas::{
             content::{AddressableContent, ExampleAddressableContent},
-            storage::EavTestSuite,
+            storage::{EavTestSuite, EavBencher}
         },
-        eav::ExampleAttribute,
+        eav::{ExampleAttribute, Attribute},
     };
     use tempfile::tempdir;
+
+    fn new_store<A: Attribute>() -> EavPickleStorage<A> {
+        let temp = tempdir().expect("test was supposed to create temp dir");
+        let temp_path = String::from(temp.path().to_str().expect("temp dir could not be string"));
+        EavPickleStorage::new(temp_path)
+    }
+
+    #[bench]
+    fn bench_pickle_add(b: &mut test::Bencher) {
+        let store = new_store();
+        EavBencher::bench_add(b, store);
+    }
+
+    #[bench]
+    fn bench_pickle_fetch(b: &mut test::Bencher) {
+        let store = new_store();
+        EavBencher::bench_fetch(b, store);        
+    }
 
     #[test]
     fn pickle_eav_round_trip() {

--- a/crates/holochain_persistence_pickle/src/eav/pickle.rs
+++ b/crates/holochain_persistence_pickle/src/eav/pickle.rs
@@ -135,15 +135,15 @@ pub mod tests {
     }
 
     #[bench]
-    fn bench_pickle_eav_add(b: &mut test::Bencher) {
+    fn bench_pickle_eav_fetch_all(b: &mut test::Bencher) {
         let store = new_store();
-        EavBencher::bench_add(b, store);
+        EavBencher::bench_fetch_all(b, store);        
     }
 
     #[bench]
-    fn bench_pickle_eav_fetch(b: &mut test::Bencher) {
+    fn bench_pickle_eav_fetch_exact(b: &mut test::Bencher) {
         let store = new_store();
-        EavBencher::bench_fetch(b, store);        
+        EavBencher::bench_fetch_exact(b, store);        
     }
 
     #[test]

--- a/crates/holochain_persistence_pickle/src/lib.rs
+++ b/crates/holochain_persistence_pickle/src/lib.rs
@@ -5,6 +5,8 @@
 //! This crate contains implementations for the CAS and EAV traits
 //! which are defined but not implemented in the core_types crate.
 #![warn(unused_extern_crates)]
-
+#![feature(test)]
+extern crate test;
+   
 pub mod cas;
 pub mod eav;

--- a/crates/holochain_persistence_pickle/src/lib.rs
+++ b/crates/holochain_persistence_pickle/src/lib.rs
@@ -8,6 +8,6 @@
 #![feature(test)]
 #[allow(unused_extern_crates)]
 extern crate test;
-   
+
 pub mod cas;
 pub mod eav;

--- a/crates/holochain_persistence_pickle/src/lib.rs
+++ b/crates/holochain_persistence_pickle/src/lib.rs
@@ -6,6 +6,7 @@
 //! which are defined but not implemented in the core_types crate.
 #![warn(unused_extern_crates)]
 #![feature(test)]
+#[allow(unused_extern_crates)]
 extern crate test;
    
 pub mod cas;


### PR DESCRIPTION
## PR summary

This PR adds a new implementation of both CAS and EAV that uses [LMDB](http://www.lmdb.tech/doc/starting.html). This is the main store used by the Monero cryptocurrency as well as being used my Mozilla in the firefox browser. As such it is well supported and has excellent [Rust bindings](https://github.com/mozilla/rkv) currently maintained by Mozilla.

LMDB maintains a sorted order of keys which, with a clever key naming scheme, allows for a huge optimization in performing queries that match exactly on an entity (the most common type of query). Rather than iterating the entire database it is possible to jump to the beginning of EAVI entries for the entry and read until the next entry. 

Benchmarks show comparable performance to PickleDB for CAS and EAV get_all retrievals but a significant improvement in get_exact queries.

```
test cas::lmdb::tests::bench_lmdb_cas_add         ... bench:      14,914 ns/iter (+/- 638)
test cas::lmdb::tests::bench_lmdb_cas_fetch       ... bench:      12,686 ns/iter (+/- 882)
test eav::lmdb::tests::bench_lmdb_eav_add         ... bench:      29,498 ns/iter (+/- 1,510)
test eav::lmdb::tests::bench_lmdb_eav_fetch_all   ... bench:   2,235,458 ns/iter (+/- 57,434)
test eav::lmdb::tests::bench_lmdb_eav_fetch_exact ... bench:       2,760 ns/iter (+/- 173)


test cas::pickle::tests::bench_pickle_cas_add         ... bench:      12,762 ns/iter (+/- 509)
test cas::pickle::tests::bench_pickle_cas_fetch       ... bench:      12,168 ns/iter (+/- 429)
test eav::pickle::tests::bench_pickle_eav_add         ... bench:      25,724 ns/iter (+/- 815)
test eav::pickle::tests::bench_pickle_eav_fetch_all   ... bench:   2,238,151 ns/iter (+/- 37,428)
test eav::pickle::tests::bench_pickle_eav_fetch_exact ... bench:     119,686 ns/iter (+/- 4,885)

```

## Future questions

- How should we decide the initial memory map size and when/how should this be increased?

## Review checklist 
- [ ] The story has unit or integration tests
- [ ] No new bugs, and any tech-debt is identified and justified
- [ ] There is enough API documentation (how to use)
- [ ] There is enough code documentation (how the code works)
