### PR TITLE
Fix bug when writing large entries

### DIFF
--- a/crates/holochain_persistence_lmdb/Cargo.toml
+++ b/crates/holochain_persistence_lmdb/Cargo.toml
@@ -28,6 +28,7 @@ bencher = "=0.1.5"
 rand = "0.7.2"
 rkv = "0.10.2"
 lmdb-rkv = "0.12.3"
+holochain_logging = "0.0.4"
 
 [dev-dependencies]
 tempfile = "=3.0.7"

--- a/crates/holochain_persistence_lmdb/src/common.rs
+++ b/crates/holochain_persistence_lmdb/src/common.rs
@@ -74,7 +74,7 @@ impl LmdbInstance {
                 trace!("Insufficient space in MMAP, doubling and trying again");
                 let map_size = env.info()?.map_size();
                 env.set_map_size(map_size * 2)?;
-                self.add(key.clone(), value)
+                self.add(key, value)
             }
             r => r, // preserve any other errors
         }?;


### PR DESCRIPTION
## PR summary

There was an issue where the MMAP would not be expanded correctly if writing one single entry larger than the current MMAP size. This was caused by the MMAP full error being thrown in a different spot in this case and not being handled correctly.

- Adds a test for writing a single entry much larger than the current mmap
- Correctly captures other error and triggers doubling process

## Review checklist 
- [ ] The story has unit or integration tests
- [ ] No new bugs, and any tech-debt is identified and justified
- [ ] There is enough API documentation (how to use)
- [ ] There is enough code documentation (how the code works)
