### PR TITLE
holochain_persistence_lmdb: fix possible deadlock in LmdbInstance::add()

### DIFF
--- a/crates/holochain_persistence_lmdb/src/common.rs
+++ b/crates/holochain_persistence_lmdb/src/common.rs
@@ -74,6 +74,7 @@ impl LmdbInstance {
                 trace!("Insufficient space in MMAP, doubling and trying again");
                 let map_size = env.info()?.map_size();
                 env.set_map_size(map_size * 2)?;
+                drop(env);
                 self.add(key, value)
             }
             r => r, // preserve any other errors


### PR DESCRIPTION
## PR summary
This PR fixes a possible deadlock in `add()`.
https://github.com/holochain/holochain-persistence/blob/9ea2c2160ef78c0ecb43db6031a070160d2dd9f0/crates/holochain_persistence_lmdb/src/common.rs#L64-L77
fn `add()` calls the `self.manager.read()` at L65, then it recursively calls itself at L77, so `self.manager.read()` is called again. A deadlock may happen when the two read locks are interleaved by a write lock from another thread. The reason is that the priority policy of `std::sync::RwLock` is [dependent on the underlying operating system's implementation](https://doc.rust-lang.org/std/sync/struct.RwLock.html). AFAIK, [Windows and macOS use fair policy](https://www.reddit.com/r/rust/comments/f4zldz/i_audited_3_different_implementation_of_async/) which leads to this kind of deadlock.

The patch is to drop the lockguard before calling `add()` again.

## Review checklist 
- [ ] The story has unit or integration tests
- [ ] No new bugs, and any tech-debt is identified and justified
- [ ] There is enough API documentation (how to use)
- [ ] There is enough code documentation (how the code works)
